### PR TITLE
Update vscode to 1.1.22

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -19,7 +19,7 @@
     "vscode-languageclient": "^4.2.1"
   },
   "devDependencies": {
-    "vscode": "^1.1.18",
+    "vscode": "^1.1.22",
     "@types/node": "^8.10.0",
     "typescript": "^2.8.3"
   }


### PR DESCRIPTION
This updates the vscode dev dependency to the newest version to make sure you don't distribute modules affected by https://code.visualstudio.com/blogs/2018/11/26/event-stream.

Please publish a new version of your extension to the marketplace after this has been merged in.