### PR TITLE
Code complete nested columns

### DIFF
--- a/example/jupyterlab/DemoPySparkSQL.ipynb
+++ b/example/jupyterlab/DemoPySparkSQL.ipynb
@@ -29,25 +29,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%load_ext sparksql_magic"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "4efad6cf-1dcf-4604-829f-0e452ee332bb",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Created `%%sql` as an alias for `%%sparksql`.\n"
-     ]
-    }
-   ],
-   "source": [
-    "%alias_magic --cell sql sparksql"
+    "%load_ext sparksql"
    ]
   },
   {
@@ -71,7 +53,7 @@
     }
    ],
    "source": [
-    "%%sql\n",
+    "%%sparksql\n",
     "CREATE TABLE student (\n",
     "    id INT, \n",
     "    name STRING,\n",
@@ -101,7 +83,7 @@
    },
    "outputs": [],
    "source": [
-    "%%sql\n",
+    "%%sparksql\n",
     "\n",
     "SELECT\n",
     "    s.books['The_Odyssey'].chapters[3].paragraph as a,\n",
@@ -133,7 +115,7 @@
     }
    ],
    "source": [
-    "%%sql\n",
+    "%%sparksql\n",
     "\n",
     "SELECT\n",
     "    s.books.title,\n",
@@ -229,7 +211,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%sql\n",
+    "%%sparksql\n",
     "SELECT \n",
     "    transform(array(1, 2, 3), x -> x + 1),\n",
     "FROM\n",
@@ -243,7 +225,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%sql\n",
+    "%%sparksql\n",
     "SELECT\n",
     "    transform(array(1, 2, 3), (x, i) -> x + i)\n",
     "FROM\n",
@@ -257,7 +239,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%sql\n",
+    "%%sparksql\n",
     "SELECT * FROM person\n",
     "    PIVOT (\n",
     "        SUM(age) AS a, AVG(class) AS c\n",
@@ -272,7 +254,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%sql\n",
+    "%%sparksql\n",
     "SELECT DATE('2020-01-01')"
    ]
   },
@@ -283,7 +265,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%sql\n",
+    "%%sparksql\n",
     "SELECT\n",
     "CAST('12' AS INT),\n",
     "X'123456' AS col,\n",
@@ -298,7 +280,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%sql\n",
+    "%%sparksql\n",
     "\n",
     "-- CTE with multiple column aliases\n",
     "WITH t(x, y) AS (SELECT 1, 2)\n",

--- a/example/jupyterlab/ExportSparkSchema.ipynb
+++ b/example/jupyterlab/ExportSparkSchema.ipynb
@@ -29,20 +29,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The sparksql_magic extension is already loaded. To reload it, use:\n",
-      "  %reload_ext sparksql_magic\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%load_ext sparksql_magic"
+    "%load_ext sparksql"
    ]
   },
   {
@@ -70,30 +61,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Alias `%%sparksql` to be `%%sql` which provides syntax highligthing"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Created `%%sql` as an alias for `%%sparksql`.\n"
-     ]
-    }
-   ],
-   "source": [
-    "%alias_magic --cell sql sparksql"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 23,
    "metadata": {},
@@ -113,7 +80,7 @@
     }
    ],
    "source": [
-    "%%sql\n",
+    "%%sparksql\n",
     "CREATE TABLE student (\n",
     "    id INT, \n",
     "    name STRING,\n",
@@ -146,7 +113,7 @@
     }
    ],
    "source": [
-    "%%sql\n",
+    "%%sparksql\n",
     "/*\n",
     "    We should have a student table in our database.    \n",
     "*/\n",
@@ -173,7 +140,7 @@
     }
    ],
    "source": [
-    "%%sql\n",
+    "%%sparksql\n",
     "/*\n",
     "    We can see the column nestedwithspaces contains sub-fields with spaces.\n",
     "    Also books is an array of structs and map_col is of MapType.\n",

--- a/example/jupyterlab/README.md
+++ b/example/jupyterlab/README.md
@@ -199,6 +199,9 @@ Code complete spark sql functions with documentation.
 
 ![functions](https://github.com/cccs-jc/sql-language-server/blob/develop/example/jupyterlab/images/code-completion-functions.gif)
 
+Automatically generate alias for tables. Expand all columns in select statement. Offer join suggestions based on matching column names from other tables in the schema.
+
+![expand-and-join-utility](https://github.com/cccs-jc/sql-language-server/blob/develop/example/jupyterlab/images/expand-and-join-utility.gif)
 
 
 ## Liting

--- a/example/jupyterlab/README.md
+++ b/example/jupyterlab/README.md
@@ -201,7 +201,7 @@ Code complete spark sql functions with documentation.
 
 Automatically generate alias for tables. Expand all columns in select statement. Offer join suggestions based on matching column names from other tables in the schema.
 
-![expand-and-join-utility](https://github.com/cccs-jc/sql-language-server/blob/develop/example/jupyterlab/images/expand-and-join-utility.gif)
+![expand-and-join-utility](https://github.com/cccs-jc/sql-language-server/blob/code-complete-nested-columns/example/jupyterlab/images/expand-and-join-utility.gif)
 
 
 ## Liting

--- a/example/jupyterlab/README.md
+++ b/example/jupyterlab/README.md
@@ -40,7 +40,8 @@ We have extended `sql-language-server` to support
     - Map and Array subscripts `map_col['key'].<tab>`, `array_col[0].<tab>`
     - Fully qualified table names `databaseName.schemaName.tableName`
 - Added utility to automatically generate all column names for a given table in a SELECT statement
-
+- Added utility to automatically generate join conditions on matching columns from other tables
+- When completing tables automatically generate table alias
 
 
 

--- a/example/jupyterlab/README.md
+++ b/example/jupyterlab/README.md
@@ -38,9 +38,8 @@ We have extended `sql-language-server` to support
 	- Table alias followed by dot
 	- Partially typed columns including multi-part fields (needed insertText)
     - Map and Array subscripts `map_col['key'].<tab>`, `array_col[0].<tab>`
-
-
-- no support for fully qualified table names `databaseName.schemaName.tableName` (might be something we want to support)
+    - Fully qualified table names `databaseName.schemaName.tableName`
+- Added utility to automatically generate all column names for a given table in a SELECT statement
 
 
 

--- a/packages/client/extension.ts
+++ b/packages/client/extension.ts
@@ -10,7 +10,8 @@ import { ExecuteCommandParams } from 'vscode-languageserver-protocol'
 import { rebuild } from './rebuild'
 
 export function activate(context: ExtensionContext) {
-  let serverModule = context.asAbsolutePath(path.join('packages', 'server', 'dist', 'cli.js'))
+  // Using the location of the javacript file built by `npm run prepublish`
+  let serverModule = context.asAbsolutePath(path.join('packages', 'server', 'dist', 'bin', 'cli.js'))
   let execArgs = ['up', '--method', 'node-ipc']
   let debugOptions = { execArgv: ["--nolazy", "--inspect=6009"] };
   let connectionNames = []

--- a/packages/server/.vscode/launch.json
+++ b/packages/server/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Jest Tests",
+            "type": "node",
+            "request": "launch",
+            "runtimeArgs": ["--inspect-brk", "${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--coverage", "false", "--debug"],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen"
+        }
+    
+    ]
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -36,7 +36,7 @@
     "dist"
   ],
   "dependencies": {
-    "@joe-re/sql-parser": "^0.11.5",
+    "@joe-re/sql-parser": "file:../sql-parser",
     "@types/pg": "^7.4.10",
     "cardinal": "^2.1.1",
     "jest": "^26.0.1",

--- a/packages/server/src/SettingStore.ts
+++ b/packages/server/src/SettingStore.ts
@@ -24,6 +24,7 @@ export type Connection = {
   filename: string | null // for sqlite3
   projectPaths: string[]
   ssh: SSHConfig | null
+  jupyterLabMode: boolean
 }
 
 type PersonalConfig = {
@@ -57,7 +58,8 @@ export default class SettingStore extends EventEmitter.EventEmitter {
     password: null,
     ssh: null,
     filename: null,
-    projectPaths: []
+    projectPaths: [],
+    jupyterLabMode: false,
   }
   private static instance: SettingStore;
 

--- a/packages/server/src/complete.ts
+++ b/packages/server/src/complete.ts
@@ -10,7 +10,7 @@ import {
   NodeRange
 } from '@joe-re/sql-parser'
 import log4js from 'log4js'
-import { Schema, Table, Column, DbFunction } from './database_libs/AbstractClient'
+import { Schema, Table, DbFunction } from './database_libs/AbstractClient'
 import { CompletionItem, CompletionItemKind } from 'vscode-languageserver-types';
 
 type Pos = { line: number, column: number }
@@ -23,9 +23,28 @@ const TABLE_ICON = CompletionItemKind.Field
 const FUNCTION_ICON = CompletionItemKind.Property
 const ALIAS_ICON = CompletionItemKind.Variable
 
+
+
+
+
 function keyword(name: string): CompletionItem {
-  return { label: name, kind: KEYWORD_ICON, detail: 'keyword' }
+  return {
+    label: name,
+    kind: KEYWORD_ICON,
+    detail: 'keyword',
+    data: { matchesLastToken: false },
+  }
 }
+
+function matchedKeyword(name: string): CompletionItem {
+  return {
+    label: name,
+    kind: KEYWORD_ICON,
+    detail: 'keyword',
+    data: { matchesLastToken: true },
+  }
+}
+
 
 const FROM_KEYWORD = keyword('FROM')
 const AS_KEYWORD = keyword('AS')
@@ -34,15 +53,15 @@ const INNERJOIN_KEYWORD = keyword('INNER JOIN')
 const LEFTJOIN_KEYWORD = keyword('LEFT JOIN')
 const ON_KEYWORD = keyword('ON')
 
-const CLAUSES: CompletionItem[] = [
-  keyword('SELECT'),
-  keyword('WHERE'),
-  keyword('ORDER BY'),
-  keyword('GROUP BY'),
-  keyword('LIMIT'),
-  keyword('--'),
-  keyword('/*'),
-  keyword('(')
+const CLAUSES: string[] = [
+  'SELECT',
+  'WHERE',
+  'ORDER BY',
+  'GROUP BY',
+  'LIMIT',
+  '--',
+  '/*',
+  '('
 ]
 
 const UNDESIRED_LITERAL = [
@@ -59,17 +78,28 @@ const UNDESIRED_LITERAL = [
   "'",
 ]
 
+function getCandidatesforKeywords(lastToken: string, keywords: string[]) {
+  return keywords.map(v => v == 'ORDER' ? 'ORDER BY' : v)
+    .map(v => v == 'GROUP' ? 'GROUP BY' : v)
+    .flatMap(v => [v.toLocaleLowerCase(), v])
+    .filter(v => v.startsWith(lastToken))
+    .map(v => matchedKeyword(v))
+}
+
+function getBasicKeywordCandidates(lastToken: string) {
+  return getCandidatesforKeywords(lastToken, CLAUSES)
+}
 // Check if parser expects us to terminate a single quote value or double quoted column name
 // SELECT TABLE1.COLUMN1 FROM TABLE1 WHERE TABLE1.COLUMN1 = "hoge.
 // We don't offer the ', the ", the ` as suggestions
-function extractExpectedLiterals(expected: { type: string, text: string }[]): CompletionItem[] {
+function extractExpectedLiterals(lastToken: string, expected: { type: string, text: string }[]): CompletionItem[] {
   const literals = expected.filter(v => v.type === 'literal').map(v => v.text)
   const uniqueLiterals = [...new Set(literals)];
-  return uniqueLiterals
+  const keywords = uniqueLiterals
     .filter(v => !UNDESIRED_LITERAL.includes(v))
     .map(v => v == 'ORDER' ? 'ORDER BY' : v)
     .map(v => v == 'GROUP' ? 'GROUP BY' : v)
-    .flatMap(v => [keyword(v.toLocaleLowerCase()), keyword(v),])
+  return getCandidatesforKeywords(lastToken, keywords)
 }
 
 // Gets the last token from the given string considering that tokens can contain dots.
@@ -99,45 +129,83 @@ function isPosInLocation(location: NodeRange, pos: Pos) {
     (location.end.line === pos.line + 1 && location.end.column >= pos.column)
 }
 
+/**
+ * Finds the most deeply nested FROM node that have a range encompasing the position.
+ * In cases such as SELECT * FROM T1 JOIN (SELECT * FROM (SELECT * FROM T2 <pos>))
+ * We will get a list of nodes like this
+ * SELECT * FROM T1
+ * (SELECT * FROM 
+ *    (SELECT * FROM T2))
+ * The idea is to reverse the list so that the most nested queries come first. Then
+ * apply a filter to keep only the FROM nodes which encompass the position and take
+ * the first one from that resulting list.
+ * @param fromNodes 
+ * @param pos 
+ * @returns 
+ */
 function getFromNodeByPos(fromNodes: FromTableNode[], pos: Pos) {
-  return fromNodes.find(v => isPosInLocation(v.location, pos))
+  return fromNodes
+    .reverse()
+    .filter(tableNode => isPosInLocation(tableNode.location, pos))
+    .shift()
 }
 
-function toCompletionItemFromTableName(tableName: string): CompletionItem {
-  return {
-    label: tableName,
-    detail: `table ${tableName}`,
-    kind: TABLE_ICON,
-  };
+// function getSelectTableCondidates(lastToken: string, tables: Table[]): CompletionItem[] {
+//   return tables
+//     .map(table => {
+//       return {
+//         lastToken: lastToken,
+//         identifier: table.tableName,
+//         detail: `table ${table.tableName}`,
+//         kind: TABLE_ICON
+//       };
+//     })
+//     .map(item => toCompletionItemIdentifierStartsWith(item))
+// }
+
+/**
+ * Given a table returns all possible ways to refer to it.
+ * That is by table name only, using the database scope,
+ * using the catalog and database scopes.
+ * @param table 
+ * @returns 
+ */
+function allTableNameCombinations(table: Table): string[] {
+  const names = [table.tableName];
+  if (table.database) names.push(table.database + '.' + table.tableName)
+  if (table.catalog) names.push(table.catalog + '.' + table.database + '.' + table.tableName)
+  return names;
 }
 
-function getSelectTableCondidates(tablePrefix: string, tables: Table[]): CompletionItem[] {
+function getTableCandidates(lastToken: string, tables: Table[]): CompletionItem[] {
   return tables
-    .filter(table => table.tableName.startsWith(tablePrefix))
-    .map(table => toCompletionItemFromTableName(table.tableName))
+    .flatMap(table => allTableNameCombinations(table))
+    .map(aTableNameVariant => {
+      return {
+        lastToken: lastToken,
+        identifier: aTableNameVariant,
+        detail: '',
+        kind: TABLE_ICON
+      }
+    })
+    .map(item => toCompletionItemIdentifierStartsWith(item))
 }
 
-function getTableCandidates(partialName: string, tables: Table[]): CompletionItem[] {
-  return tables.flatMap(table => {
-    const names = [table.tableName];
-    if (table.database) names.push(table.database + '.' + table.tableName)
-    if (table.catalog) names.push(table.catalog + '.' + table.database + '.' + table.tableName)
-    return names;
-  })
-  .map(name => toCompletionItemMatchingLastToken(partialName, name))
-}
-
-function getColumnCondidates(tablePrefix: string, tables: Table[]): CompletionItem[] {
-  const tableCandidates: string[] = tables
-    .filter(table => table.tableName.startsWith(tablePrefix))
-    .map(table => table.tableName)
-  const columns: Column[] = tables
-    .filter(table => tableCandidates.includes(table.tableName))
+function getColumnCondidatesFromAnyTable(lastToken: string, tables: Table[]): CompletionItem[] {
+  return tables
     .flatMap(table => table.columns)
-  return columns.map(c => toCompletionItemFromColumn('', tablePrefix, c))
+    .map(column => {
+      return {
+        lastToken: lastToken,
+        identifier: column.columnName,
+        detail: column.description,
+        kind: COLUMN_ICON
+      }
+    })
+    .map(item => toCompletionItemIdentifierStartsWith(item))
 }
 
-function getCandidatedFromIncompleteSubquery(incompleteSubquery: IncompleteSubqueryNode, pos: Pos, schema: Schema): CompletionItem[] {
+function getCandidatesForIncompleteSubquery(incompleteSubquery: IncompleteSubqueryNode, pos: Pos, schema: Schema): CompletionItem[] {
   let candidates: CompletionItem[] = []
   const parsedFromClause = getFromNodesFromClause(incompleteSubquery.text)
   try {
@@ -172,23 +240,31 @@ function createTablesFromFromNodes(fromNodes: FromTableNode[]): Table[] {
   }, [])
 }
 
-function getCandidatesFromError(lastToken: string, schema: Schema, _pos: Pos, e: any, fromNodes: FromTableNode[]): CompletionItem[] {
-  switch (e.message) {
-    case 'EXPECTED COLUMN NAME': {
-      return getColumnCondidates('', schema.tables)
-    }
-  }
-  let candidates = extractExpectedLiterals(e.expected || [])
+/**
+ * INSERT INTO TABLE1 (C
+ */
+function getCandidatesForInsert(lastToken: string, schema: Schema): CompletionItem[] {
+  return getColumnCondidatesFromAnyTable(lastToken, schema.tables)
+}
 
+function getCandidatesForError(lastToken: string, schema: Schema, e: any): CompletionItem[] {
+  let candidates = extractExpectedLiterals(lastToken, e.expected || [])
+  candidates = candidates.concat(
+    getFunctionCondidates(lastToken, schema.functions),
+    getTableCandidates(lastToken, schema.tables)
+  )
+  return candidates
+}
+
+function getCandidatesForQuery(lastToken: string, schema: Schema, _pos: Pos, e: any, fromNodes: FromTableNode[]): CompletionItem[] {
+  let candidates = extractExpectedLiterals(lastToken, e.expected || [])
   const subqueryTables = createTablesFromFromNodes(fromNodes)
   const schemaAndSubqueries = schema.tables.concat(subqueryTables)
-  const partialName = lastToken
   candidates = candidates.concat(
-    getColumnCandidatesByTableScope(lastToken, schemaAndSubqueries, partialName),
-    getColumnCandidatesByAliasScope(lastToken, fromNodes, schemaAndSubqueries, partialName),
-    getFunctionCondidates(partialName, schema.functions),
-    getColumnCandidates(fromNodes, schemaAndSubqueries, partialName),
-    getTableCandidates(partialName, schemaAndSubqueries)
+    getScopedColumnCandidates(lastToken, fromNodes, schemaAndSubqueries),
+    getFunctionCondidates(lastToken, schema.functions),
+    getAliasCandidates(lastToken, fromNodes),
+    getTableCandidates(lastToken, schemaAndSubqueries)
   )
   if (logger.isDebugEnabled()) logger.debug(`candidates for error returns: ${JSON.stringify(candidates)}`)
   return candidates
@@ -207,12 +283,17 @@ function getRidOfAfterCursorString(sql: string, pos: Pos) {
   return sql.split('\n').filter((_v, idx) => pos.line >= idx).map((v, idx) => idx === pos.line ? v.slice(0, pos.column) : v).join('\n')
 }
 
-function completeDeleteStatement(ast: DeleteStatement, pos: Pos, tables: Table[]): CompletionItem[] {
+function completeDeleteStatement(lastToken: string, ast: DeleteStatement, pos: Pos, tables: Table[]): CompletionItem[] {
   if (isPosInLocation(ast.table.location, pos)) {
-    return getTableCandidates('', tables)
+    const lastToken = makeLastToken(ast.table)
+    return getTableCandidates(lastToken, tables)
   }
   else if (ast.where && isPosInLocation(ast.where.expression.location, pos)) {
-    return getColumnCondidates('', tables)
+    const expr = ast.where.expression
+    if (expr.type === 'column_ref') {
+      lastToken = makeColumnName(expr.table, expr.column)
+      return getColumnCondidatesFromAnyTable(lastToken, tables)
+    }
   }
   return []
 }
@@ -238,14 +319,33 @@ function completeSelectStatement(ast: SelectStatement, _pos: Pos, _tables: Table
   return candidates
 }
 
+/**
+ * Recursively pull out the FROM nodes (including sub-queries)
+ * @param tableNodes
+ * @returns 
+ */
+function getAllNestedFromNodes(tableNodes: FromTableNode[]): FromTableNode[] {
+  return tableNodes.flatMap(tableNode => {
+    let result = [tableNode]
+    if (tableNode.type == 'subquery') {
+      const subTableNodes = tableNode.subquery.from?.tables || []
+      result = result.concat(getAllNestedFromNodes(subTableNodes))
+    }
+    return result
+  })
+}
+
+let lastToken = ''
+let candidates: CompletionItem[] = []
+
 export function complete(sql: string, pos: Pos, schema: Schema = { tables: [], functions: [] }) {
   if (logger.isDebugEnabled()) logger.debug(`complete: ${sql}, ${JSON.stringify(pos)}`)
-  let candidates: CompletionItem[] = []
+  candidates = []
   let error = null;
 
   const target = getRidOfAfterCursorString(sql, pos)
   logger.debug(`target: ${target}`)
-  const lastToken = getLastToken(target)
+  lastToken = getLastToken(target)
   try {
     const ast = parse(target);
     candidates = getCandidatesForParsedQuery(lastToken, sql, ast, schema, pos)
@@ -256,13 +356,21 @@ export function complete(sql: string, pos: Pos, schema: Schema = { tables: [], f
       throw e
     }
     const parsedFromClause = getFromNodesFromClause(sql)
-    const fromNodes = parsedFromClause?.from?.tables || []
-    const fromNodeOnCursor = getFromNodeByPos(fromNodes || [], pos)
-    if (fromNodeOnCursor && fromNodeOnCursor.type === 'incomplete_subquery') {
-      // Incomplete sub query 'SELECT sub FROM (SELECT e. FROM employees e) sub'
-      candidates = getCandidatedFromIncompleteSubquery(fromNodeOnCursor, pos, schema)
-    } else {
-      candidates = getCandidatesFromError(lastToken, schema, pos, e, fromNodes)
+    if (parsedFromClause) {
+      const fromNodes = getAllNestedFromNodes(parsedFromClause?.from?.tables || [])
+      const fromNodeOnCursor = getFromNodeByPos(fromNodes, pos)
+      if (fromNodeOnCursor && fromNodeOnCursor.type === 'incomplete_subquery') {
+        // Incomplete sub query 'SELECT sub FROM (SELECT e. FROM employees e) sub'
+        candidates = getCandidatesForIncompleteSubquery(fromNodeOnCursor, pos, schema)
+      } else {
+        candidates = getCandidatesForQuery(lastToken, schema, pos, e, fromNodes)
+      }
+    }
+    else if (e.message === 'EXPECTED COLUMN NAME') {
+      candidates = getCandidatesForInsert(lastToken, schema)
+    }
+    else {
+      candidates = getCandidatesForError(lastToken, schema, e)
     }
     error = { label: e.name, detail: e.message, line: e.line, offset: e.offset }
   }
@@ -282,16 +390,17 @@ function filterCandidatesUsingLastToken(lastToken: string, candidates: Completio
 
 function getCandidatesForParsedQuery(lastToken: string, sql: string, ast: any, schema: Schema, pos: Pos): CompletionItem[] {
   if (logger.isDebugEnabled()) logger.debug(`getting candidates for parse query ast: ${JSON.stringify(ast)}`)
-  if (ast.type === 'delete') {
-    return completeDeleteStatement(ast, pos, schema.tables)
+  if (!ast.type) {
+    return getBasicKeywordCandidates(lastToken)
   }
-  else {
-    let candidates = CLAUSES
-    if (ast.type === 'select') {
-      candidates = candidates.concat(completeSelectStatement(ast, pos, schema.tables))
-      if (!ast.distinct) {
-        candidates.push(DISTINCT_KEYWORD)
-      }
+  if (ast.type === 'delete') {
+    return completeDeleteStatement('', ast, pos, schema.tables)
+  }
+  else if (ast.type === 'select') {
+    let candidates = getBasicKeywordCandidates(lastToken)
+    candidates = candidates.concat(completeSelectStatement(ast, pos, schema.tables))
+    if (!ast.distinct) {
+      candidates.push(DISTINCT_KEYWORD)
     }
     const columnRef = getColumnAtPosition(ast, pos)
     if (!columnRef) {
@@ -302,29 +411,34 @@ function getCandidatesForParsedQuery(lastToken: string, sql: string, ast: any, s
       const fromNodes = parsedFromClause?.from?.tables || []
       const subqueryTables = createTablesFromFromNodes(fromNodes)
       const schemaAndSubqueries = schema.tables.concat(subqueryTables)
-
       if (columnRef.table) {
         // We know what table/alias this column belongs to
         const partialColumnName = columnRef.column
         const tableOrAlias = columnRef.table
-        let scopedPartialColumnName = tableOrAlias + '.' + partialColumnName
+        // Strip out any subscripts t.abc[0].xyz
+        const lastToken2 = getLastToken(' ' + tableOrAlias + '.' + partialColumnName)
         // Find the corresponding table and suggest it's columns
         candidates = candidates.concat(
-          getColumnCandidatesByTableScope(lastToken, schemaAndSubqueries, scopedPartialColumnName),
-          getColumnCandidatesByAliasScope(lastToken, fromNodes, schemaAndSubqueries, scopedPartialColumnName))
+          getScopedColumnCandidates(lastToken2, fromNodes, schemaAndSubqueries))
       }
       else {
         // Column is not scoped to a table/alias yet
-        const partialName = columnRef.column
+        const lastToken2 = columnRef.column
         // Could be an alias, a talbe or a function
         candidates = candidates.concat(
-          getColumnCandidates(fromNodes, schemaAndSubqueries, partialName),
-          getSelectTableCondidates(partialName, schema.tables),
-          getFunctionCondidates(partialName, schema.functions))
+          getAliasCandidates(lastToken2, fromNodes),
+          getTableCandidates(lastToken2, schemaAndSubqueries),
+
+          //getSelectTableCondidates(partialName, schema.tables),
+          getFunctionCondidates(lastToken2, schema.functions))
       }
     }
     if (logger.isDebugEnabled()) logger.debug(`parse query returns: ${JSON.stringify(candidates)}`)
     return candidates
+  }
+  else {
+    console.log(`AST type not supported yet: ${ast.type}`)
+    return []
   }
 }
 function makeLastToken(fromTable: any): string {
@@ -335,27 +449,6 @@ function makeLastToken(fromTable: any): string {
   return parts.join('.')
 }
 
-function toCompletionItemMatchingLastToken (lastToken: string, tableName: string): CompletionItem {
-  if (lastToken.indexOf('.') > 0) {
-    const matchesLastToken = tableName.startsWith(lastToken);
-    const remainingNamePart = tableName.substr(lastToken.lastIndexOf('.') + 1)
-    return {
-      label: remainingNamePart,
-      filterText: '.' + remainingNamePart,
-      insertText: '.' + remainingNamePart,
-      detail: `table ${remainingNamePart}`,
-      kind: TABLE_ICON,
-      data: { matchesLastToken: matchesLastToken },
-    }
-  }
-  else {
-    return {
-      label: tableName,
-      detail: `table ${tableName}`,
-      kind: TABLE_ICON,
-    }
-  }
-}
 
 
 function getJoinCondidates(ast: any, schema: Schema, pos: Pos): CompletionItem[] {
@@ -398,41 +491,51 @@ function toCompletionItemFromFunction(f: DbFunction): CompletionItem {
     label: f.name,
     detail: 'function',
     kind: FUNCTION_ICON,
-    documentation: f.description
+    documentation: f.description,
+    data: { matchesLastToken: true },
   }
 }
 
-function toCompletionItemFromAlias(alias: string): CompletionItem {
+function toCompletionItemForAlias(alias: string): CompletionItem {
   return {
     label: alias,
     detail: 'alias',
     kind: ALIAS_ICON,
+    data: { matchesLastToken: true },
   }
 }
 
-function toCompletionItemFromColumn(lastToken: string, alias: string, column: Column): CompletionItem {
-  let columnName = column.columnName
-  if (alias) {
-    const scopedColumnName = `${alias}.${columnName}`
-    const matchesLastToken = scopedColumnName.startsWith(lastToken);
-    const remainingColumnName = scopedColumnName.substr(lastToken.lastIndexOf('.') + 1)
+type Identifier = {
+  lastToken: string,
+  identifier: string,
+  detail: string,
+  kind: CompletionItemKind
+}
+
+function toCompletionItemIdentifierStartsWith(item: Identifier): CompletionItem {
+  const kindName = item.kind == TABLE_ICON ? 'table' : 'column'
+  const matchesLastToken = item.identifier.startsWith(item.lastToken);
+  if (item.lastToken.indexOf('.') > 0) {
+    const remainingNamePart = item.identifier.substr(item.lastToken.lastIndexOf('.') + 1)
     return {
-      label: remainingColumnName,
-      filterText: '.' + remainingColumnName,
-      insertText: '.' + remainingColumnName,
-      detail: `column ${column.description}`,
-      kind: COLUMN_ICON,
+      label: remainingNamePart,
+      filterText: '.' + remainingNamePart,
+      insertText: '.' + remainingNamePart,
+      detail: `${kindName} ${item.detail}`,
+      kind: item.kind,
       data: { matchesLastToken: matchesLastToken },
     }
   }
   else {
     return {
-      label: columnName,
-      detail: `column ${column.description}`,
-      kind: COLUMN_ICON,
+      label: item.identifier,
+      detail: `${kindName} ${item.identifier}`,
+      kind: item.kind,
+      data: { matchesLastToken: matchesLastToken },
     }
   }
 }
+
 function getFunctionCondidates(prefix: string, functions: DbFunction[]): CompletionItem[] {
   if (!prefix) {
     // Nothing was typed, return all lowercase functions
@@ -455,56 +558,54 @@ function getFunctionCondidates(prefix: string, functions: DbFunction[]): Complet
 
 }
 
-function getColumnCandidatesByTableScope(lastToken: string, tables: Table[], scopedPartialColumName: string): CompletionItem[] {
-  return tables
-    .filter(table => scopedPartialColumName.startsWith(table.tableName + '.'))
-    .flatMap(table =>
-      table.columns.map(col => {
-        return { column: col, tableName: table.tableName }
-      })
-    )
-    .map(colInfo => toCompletionItemFromColumn(lastToken, colInfo.tableName, colInfo.column))
+function makeColumnName(alias: string, columnName: string) {
+  if (alias) {
+    return alias + '.' + columnName;
+  }
+  return columnName;
 }
 
-function getColumnCandidatesByAliasScope(lastToken: string, fromNodes: FromTableNode[], tables: Table[], scopedPartialColumName: string): CompletionItem[] {
+function getScopedColumnCandidates(lastToken: string, fromNodes: FromTableNode[], tables: Table[]): CompletionItem[] {
   return tables.flatMap(table => {
-    return fromNodes.filter((fromNode: any) =>
-      tableMatch(fromNode, table) &&
-      fromNode.as &&
-      scopedPartialColumName.startsWith(fromNode.as + '.')
-    )
-      .flatMap(fromNode =>
+    return fromNodes.filter((fromNode: any) => tableMatch(fromNode, table))
+      .map((fromNode: any) => fromNode.as || fromNode.table)
+      .filter(alias => lastToken.startsWith(alias + '.')
+      )
+      .flatMap(alias =>
         table.columns.map(col => {
-          return { column: col, alias: fromNode.as }
+          return {
+            lastToken: lastToken,
+            identifier: makeColumnName(alias, col.columnName),
+            detail: col.description,
+            kind: COLUMN_ICON
+          }
         })
       )
-      .map(colInfo => toCompletionItemFromColumn(lastToken, colInfo.alias || '', colInfo.column))
+      .map(item => toCompletionItemIdentifierStartsWith(item))
   })
 }
 
 function tableMatch(fromNode: any, table: Table) {
-  if (fromNode.table != table.tableName) {
+  if (fromNode.type == 'subquery' &&
+    fromNode.as &&
+    fromNode.as != table.tableName) {
     return false;
   }
-
-  if (fromNode.db && fromNode.db != table.database) {
+  else if (fromNode.table && fromNode.table != table.tableName) {
     return false;
   }
-
-  if (fromNode.catalog && fromNode.catalog != table.catalog) {
+  else if (fromNode.db && fromNode.db != table.database) {
     return false;
   }
-
+  else if (fromNode.catalog && fromNode.catalog != table.catalog) {
+    return false;
+  }
   return true;
 }
 
-function getColumnCandidates(fromNodes: FromTableNode[], tables: Table[], partialName: string): CompletionItem[] {
-  return tables.flatMap(table => {
-    return fromNodes.filter((fromNode: any) =>
-      fromNode.as &&
-      fromNode.as.startsWith(partialName) &&
-      tableMatch(fromNode, table)
-    )
-      .map(fromNode => toCompletionItemFromAlias(fromNode.as || ''))
-  })
+function getAliasCandidates(lastToken: string, fromNodes: FromTableNode[]): CompletionItem[] {
+  return fromNodes
+    .map((fromNode: any) => fromNode.as)
+    .filter(aliasName => aliasName && aliasName.startsWith(lastToken))
+    .map(aliasName => toCompletionItemForAlias(aliasName))
 }

--- a/packages/server/src/complete.ts
+++ b/packages/server/src/complete.ts
@@ -486,6 +486,7 @@ class Completer {
   }
 
   addCandidatesForFunctions() {
+    console.time('addCandidatesForFunctions')
     if (!this.lastToken) {
       // Nothing was typed, return all lowercase functions
       this.schema.functions
@@ -507,6 +508,7 @@ class Completer {
         .map(v => toCompletionItemForFunction(v))
         .forEach(item => this.addCandidate(item))
     }
+    console.timeEnd('addCandidatesForFunctions')
   }
 
   makeColumnName(alias: string, columnName: string) {
@@ -514,6 +516,7 @@ class Completer {
   }
 
   addCandidatesForScopedColumns(fromNodes: FromTableNode[], tables: Table[]) {
+    console.time('addCandidatesForScopedColumns')
     tables.flatMap(table => {
       return fromNodes.filter((fromNode: any) => this.tableMatch(fromNode, table))
         .map((fromNode: any) => fromNode.as || fromNode.table)
@@ -532,6 +535,7 @@ class Completer {
       .filter(item => item.matchesLastToken())
       .map(item => item.toCompletionItem())
       .forEach(item => this.addCandidate(item))
+    console.timeEnd('addCandidatesForScopedColumns')
   }
 
   /**
@@ -577,8 +581,10 @@ class Completer {
 
 
 export function complete(sql: string, pos: Pos, schema: Schema = { tables: [], functions: [] }) {
+  console.time('complete')
   if (logger.isDebugEnabled()) logger.debug(`complete: ${sql}, ${JSON.stringify(pos)}`)
   const completer = new Completer(schema, sql, pos)
   const candidates = completer.complete()
+  console.timeEnd('complete')
   return { candidates: candidates, error: completer.error }
 }

--- a/packages/server/src/complete.ts
+++ b/packages/server/src/complete.ts
@@ -68,7 +68,13 @@ export class Identifier {
   }
 
   matchesLastToken(): boolean {
-    return this.identifier.startsWith(this.lastToken)
+    if (this.identifier.startsWith(this.lastToken)) {
+      // prevent suggesting the lastToken itself, there is nothing to complete in that case
+      if (this.identifier !== this.lastToken) {
+        return true;
+      }
+    }
+    return false;
   }
 
   toCompletionItem(): CompletionItem {

--- a/packages/server/src/complete.ts
+++ b/packages/server/src/complete.ts
@@ -81,16 +81,27 @@ export class Identifier {
     const kindName = this.kind == TABLE_ICON ? 'table' : 'column'
     const idx = this.lastToken.lastIndexOf('.')
     const namePart = this.identifier.substr(idx + 1)
-    const dot = idx > 0 ? '.' : ''
-    return {
-      label: namePart,
-      filterText: dot + namePart,
-      insertText: dot + namePart,
-      detail: `${kindName} ${this.detail}`,
-      kind: this.kind,
+    const isDotTriggerCharacter = (idx == (this.lastToken.length - 1))
+    if (isDotTriggerCharacter) {
+      const text = '.' + namePart
+      return {
+        label: namePart,
+        filterText: text,
+        insertText: text,
+        detail: `${kindName} ${this.detail}`,
+        kind: this.kind,
+      }
+    }
+    else {
+      return {
+        label: namePart,
+        detail: `${kindName} ${this.detail}`,
+        kind: this.kind,
+      }
     }
   }
 }
+
 
 // Gets the last token from the given string considering that tokens can contain dots.
 export function getLastToken(sql: string) {

--- a/packages/server/src/complete.ts
+++ b/packages/server/src/complete.ts
@@ -17,41 +17,18 @@ type Pos = { line: number, column: number }
 
 const logger = log4js.getLogger()
 
-const KEYWORD_ICON = CompletionItemKind.Event
-const COLUMN_ICON = CompletionItemKind.Interface
-const TABLE_ICON = CompletionItemKind.Field
-const FUNCTION_ICON = CompletionItemKind.Property
-const ALIAS_ICON = CompletionItemKind.Variable
+export const KEYWORD_ICON = CompletionItemKind.Event
+export const COLUMN_ICON = CompletionItemKind.Interface
+export const TABLE_ICON = CompletionItemKind.Field
+export const FUNCTION_ICON = CompletionItemKind.Property
+export const ALIAS_ICON = CompletionItemKind.Variable
 
-
-
-
-
-function keyword(name: string): CompletionItem {
-  return {
-    label: name,
-    kind: KEYWORD_ICON,
-    detail: 'keyword',
-    data: { matchesLastToken: false },
-  }
-}
-
-function matchedKeyword(name: string): CompletionItem {
-  return {
-    label: name,
-    kind: KEYWORD_ICON,
-    detail: 'keyword',
-    data: { matchesLastToken: true },
-  }
-}
-
-
-const FROM_KEYWORD = keyword('FROM')
-const AS_KEYWORD = keyword('AS')
-const DISTINCT_KEYWORD = keyword('DISTINCT')
-const INNERJOIN_KEYWORD = keyword('INNER JOIN')
-const LEFTJOIN_KEYWORD = keyword('LEFT JOIN')
-const ON_KEYWORD = keyword('ON')
+const FROM_KEYWORD = toCompletionItemForKeyword('FROM')
+const AS_KEYWORD = toCompletionItemForKeyword('AS')
+const DISTINCT_KEYWORD = toCompletionItemForKeyword('DISTINCT')
+const INNERJOIN_KEYWORD = toCompletionItemForKeyword('INNER JOIN')
+const LEFTJOIN_KEYWORD = toCompletionItemForKeyword('LEFT JOIN')
+const ON_KEYWORD = toCompletionItemForKeyword('ON')
 
 const CLAUSES: string[] = [
   'SELECT',
@@ -78,28 +55,35 @@ const UNDESIRED_LITERAL = [
   "'",
 ]
 
-function getCandidatesforKeywords(lastToken: string, keywords: string[]) {
-  return keywords.map(v => v == 'ORDER' ? 'ORDER BY' : v)
-    .map(v => v == 'GROUP' ? 'GROUP BY' : v)
-    .flatMap(v => [v.toLocaleLowerCase(), v])
-    .filter(v => v.startsWith(lastToken))
-    .map(v => matchedKeyword(v))
-}
+export class Identifier {
+  lastToken: string
+  identifier: string
+  detail: string
+  kind: CompletionItemKind
+  constructor(lastToken: string, identifier: string, detail: string, kind: CompletionItemKind) {
+    this.lastToken = lastToken
+    this.identifier = identifier
+    this.detail = detail
+    this.kind = kind
+  }
 
-function getBasicKeywordCandidates(lastToken: string) {
-  return getCandidatesforKeywords(lastToken, CLAUSES)
-}
-// Check if parser expects us to terminate a single quote value or double quoted column name
-// SELECT TABLE1.COLUMN1 FROM TABLE1 WHERE TABLE1.COLUMN1 = "hoge.
-// We don't offer the ', the ", the ` as suggestions
-function extractExpectedLiterals(lastToken: string, expected: { type: string, text: string }[]): CompletionItem[] {
-  const literals = expected.filter(v => v.type === 'literal').map(v => v.text)
-  const uniqueLiterals = [...new Set(literals)];
-  const keywords = uniqueLiterals
-    .filter(v => !UNDESIRED_LITERAL.includes(v))
-    .map(v => v == 'ORDER' ? 'ORDER BY' : v)
-    .map(v => v == 'GROUP' ? 'GROUP BY' : v)
-  return getCandidatesforKeywords(lastToken, keywords)
+  matchesLastToken(): boolean {
+    return this.identifier.startsWith(this.lastToken)
+  }
+
+  toCompletionItem(): CompletionItem {
+    const kindName = this.kind == TABLE_ICON ? 'table' : 'column'
+    const idx = this.lastToken.lastIndexOf('.')
+    const namePart = this.identifier.substr(idx + 1)
+    const dot = idx > 0 ? '.' : ''
+    return {
+      label: namePart,
+      filterText: dot + namePart,
+      insertText: dot + namePart,
+      detail: `${kindName} ${this.detail}`,
+      kind: this.kind,
+    }
+  }
 }
 
 // Gets the last token from the given string considering that tokens can contain dots.
@@ -117,157 +101,30 @@ export function getLastToken(sql: string) {
   return sql;
 }
 
-function getColumnRefByPos(columns: ColumnRefNode[], pos: Pos) {
-  return columns.find(v =>
-    (v.location.start.line === pos.line + 1 && v.location.start.column <= pos.column) &&
-    (v.location.end.line === pos.line + 1 && v.location.end.column >= pos.column)
-  )
-}
 
-function isPosInLocation(location: NodeRange, pos: Pos) {
-  return (location.start.line === pos.line + 1 && location.start.column <= pos.column) &&
-    (location.end.line === pos.line + 1 && location.end.column >= pos.column)
-}
-
-/**
- * Finds the most deeply nested FROM node that have a range encompasing the position.
- * In cases such as SELECT * FROM T1 JOIN (SELECT * FROM (SELECT * FROM T2 <pos>))
- * We will get a list of nodes like this
- * SELECT * FROM T1
- * (SELECT * FROM 
- *    (SELECT * FROM T2))
- * The idea is to reverse the list so that the most nested queries come first. Then
- * apply a filter to keep only the FROM nodes which encompass the position and take
- * the first one from that resulting list.
- * @param fromNodes 
- * @param pos 
- * @returns 
- */
-function getFromNodeByPos(fromNodes: FromTableNode[], pos: Pos) {
-  return fromNodes
-    .reverse()
-    .filter(tableNode => isPosInLocation(tableNode.location, pos))
-    .shift()
-}
-
-// function getSelectTableCondidates(lastToken: string, tables: Table[]): CompletionItem[] {
-//   return tables
-//     .map(table => {
-//       return {
-//         lastToken: lastToken,
-//         identifier: table.tableName,
-//         detail: `table ${table.tableName}`,
-//         kind: TABLE_ICON
-//       };
-//     })
-//     .map(item => toCompletionItemIdentifierStartsWith(item))
-// }
-
-/**
- * Given a table returns all possible ways to refer to it.
- * That is by table name only, using the database scope,
- * using the catalog and database scopes.
- * @param table 
- * @returns 
- */
-function allTableNameCombinations(table: Table): string[] {
-  const names = [table.tableName];
-  if (table.database) names.push(table.database + '.' + table.tableName)
-  if (table.catalog) names.push(table.catalog + '.' + table.database + '.' + table.tableName)
-  return names;
-}
-
-function getTableCandidates(lastToken: string, tables: Table[]): CompletionItem[] {
-  return tables
-    .flatMap(table => allTableNameCombinations(table))
-    .map(aTableNameVariant => {
-      return {
-        lastToken: lastToken,
-        identifier: aTableNameVariant,
-        detail: '',
-        kind: TABLE_ICON
-      }
-    })
-    .map(item => toCompletionItemIdentifierStartsWith(item))
-}
-
-function getColumnCondidatesFromAnyTable(lastToken: string, tables: Table[]): CompletionItem[] {
-  return tables
-    .flatMap(table => table.columns)
-    .map(column => {
-      return {
-        lastToken: lastToken,
-        identifier: column.columnName,
-        detail: column.description,
-        kind: COLUMN_ICON
-      }
-    })
-    .map(item => toCompletionItemIdentifierStartsWith(item))
-}
-
-function getCandidatesForIncompleteSubquery(incompleteSubquery: IncompleteSubqueryNode, pos: Pos, schema: Schema): CompletionItem[] {
-  let candidates: CompletionItem[] = []
-  const parsedFromClause = getFromNodesFromClause(incompleteSubquery.text)
-  try {
-    parse(incompleteSubquery.text);
-  } catch (e) {
-    if (e.name !== 'SyntaxError') {
-      throw e
-    }
-    const fromText = incompleteSubquery.text
-    const newPos = parsedFromClause ? {
-      line: pos.line - (incompleteSubquery.location.start.line - 1),
-      column: pos.column - incompleteSubquery.location.start.column + 1
-    } : { line: 0, column: 0 }
-    candidates = complete(fromText, newPos, schema).candidates
+function toCompletionItemForKeyword(name: string): CompletionItem {
+  return {
+    label: name,
+    kind: KEYWORD_ICON,
+    detail: 'keyword',
   }
-  return candidates
 }
 
-function createTablesFromFromNodes(fromNodes: FromTableNode[]): Table[] {
-  return fromNodes.reduce((p: any, c) => {
-    if (c.type !== 'subquery') {
-      return p
-    }
-    if (!Array.isArray(c.subquery.columns)) {
-      return p
-    }
-    const columns = c.subquery.columns.map(v => {
-      if (typeof v === 'string') { return null }
-      return { columnName: v.as || (v.expr.type === 'column_ref' && v.expr.column) || '', description: 'alias' }
-    })
-    return p.concat({ database: null, columns, tableName: c.as })
-  }, [])
+function toCompletionItemForFunction(f: DbFunction): CompletionItem {
+  return {
+    label: f.name,
+    detail: 'function',
+    kind: FUNCTION_ICON,
+    documentation: f.description,
+  }
 }
 
-/**
- * INSERT INTO TABLE1 (C
- */
-function getCandidatesForInsert(lastToken: string, schema: Schema): CompletionItem[] {
-  return getColumnCondidatesFromAnyTable(lastToken, schema.tables)
-}
-
-function getCandidatesForError(lastToken: string, schema: Schema, e: any): CompletionItem[] {
-  let candidates = extractExpectedLiterals(lastToken, e.expected || [])
-  candidates = candidates.concat(
-    getFunctionCondidates(lastToken, schema.functions),
-    getTableCandidates(lastToken, schema.tables)
-  )
-  return candidates
-}
-
-function getCandidatesForQuery(lastToken: string, schema: Schema, _pos: Pos, e: any, fromNodes: FromTableNode[]): CompletionItem[] {
-  let candidates = extractExpectedLiterals(lastToken, e.expected || [])
-  const subqueryTables = createTablesFromFromNodes(fromNodes)
-  const schemaAndSubqueries = schema.tables.concat(subqueryTables)
-  candidates = candidates.concat(
-    getScopedColumnCandidates(lastToken, fromNodes, schemaAndSubqueries),
-    getFunctionCondidates(lastToken, schema.functions),
-    getAliasCandidates(lastToken, fromNodes),
-    getTableCandidates(lastToken, schemaAndSubqueries)
-  )
-  if (logger.isDebugEnabled()) logger.debug(`candidates for error returns: ${JSON.stringify(candidates)}`)
-  return candidates
+function toCompletionItemForAlias(alias: string): CompletionItem {
+  return {
+    label: alias,
+    detail: 'alias',
+    kind: ALIAS_ICON,
+  }
 }
 
 function getFromNodesFromClause(sql: string): FromClauseParserResult | null {
@@ -279,333 +136,443 @@ function getFromNodesFromClause(sql: string): FromClauseParserResult | null {
   }
 }
 
-function getRidOfAfterCursorString(sql: string, pos: Pos) {
-  return sql.split('\n').filter((_v, idx) => pos.line >= idx).map((v, idx) => idx === pos.line ? v.slice(0, pos.column) : v).join('\n')
-}
-
-function completeDeleteStatement(lastToken: string, ast: DeleteStatement, pos: Pos, tables: Table[]): CompletionItem[] {
-  if (isPosInLocation(ast.table.location, pos)) {
-    const lastToken = makeLastToken(ast.table)
-    return getTableCandidates(lastToken, tables)
+class Completer {
+  lastToken: string;
+  candidates: CompletionItem[]
+  schema: Schema
+  error: any
+  sql: string
+  pos: Pos
+  constructor(schema: Schema, sql: string, pos: Pos) {
+    this.lastToken = ''
+    this.schema = schema
+    this.candidates = []
+    this.error = ''
+    this.sql = sql
+    this.pos = pos
   }
-  else if (ast.where && isPosInLocation(ast.where.expression.location, pos)) {
-    const expr = ast.where.expression
-    if (expr.type === 'column_ref') {
-      lastToken = makeColumnName(expr.table, expr.column)
-      return getColumnCondidatesFromAnyTable(lastToken, tables)
+
+  complete() {
+    const target = this.getRidOfAfterCursorString()
+    logger.debug(`target: ${target}`)
+    this.lastToken = getLastToken(target)
+    try {
+      const ast = parse(target);
+      this.addCandidatesForParsedStatement(ast)
+    } catch (e) {
+      logger.debug('error')
+      logger.debug(e)
+      if (e.name !== 'SyntaxError') {
+        throw e
+      }
+      const parsedFromClause = getFromNodesFromClause(this.sql)
+      if (parsedFromClause) {
+        const fromNodes = this.getAllNestedFromNodes(parsedFromClause?.from?.tables || [])
+        const fromNodeOnCursor = this.getFromNodeByPos(fromNodes)
+        if (fromNodeOnCursor && fromNodeOnCursor.type === 'incomplete_subquery') {
+          // Incomplete sub query 'SELECT sub FROM (SELECT e. FROM employees e) sub'
+          this.addCandidatesForIncompleteSubquery(fromNodeOnCursor)
+        }
+        else {
+          this.addCandidatesForSelectQuery(e, fromNodes)
+        }
+      }
+      else if (e.message === 'EXPECTED COLUMN NAME') {
+        this.addCandidatesForInsert()
+      }
+      else {
+        this.addCandidatesForError(e)
+      }
+      this.error = { label: e.name, detail: e.message, line: e.line, offset: e.offset }
+    }
+    return this.candidates
+  }
+
+  addCandidatesforKeywords(keywords: string[]) {
+    keywords.map(v => v == 'ORDER' ? 'ORDER BY' : v)
+      .map(v => v == 'GROUP' ? 'GROUP BY' : v)
+      .flatMap(v => [v.toLocaleLowerCase(), v])
+      .filter(v => v.startsWith(this.lastToken))
+      .map(v => toCompletionItemForKeyword(v))
+      .forEach(item => this.addCandidate(item))
+  }
+
+  addCandidatesForBasicKeyword() {
+    this.addCandidatesforKeywords(CLAUSES)
+  }
+
+  // Check if parser expects us to terminate a single quote value or double quoted column name
+  // SELECT TABLE1.COLUMN1 FROM TABLE1 WHERE TABLE1.COLUMN1 = "hoge.
+  // We don't offer the ', the ", the ` as suggestions
+  addCandidatesForExpectedLiterals(expected: { type: string, text: string }[]) {
+    const literals = expected.filter(v => v.type === 'literal').map(v => v.text)
+    const uniqueLiterals = [...new Set(literals)];
+    const keywords = uniqueLiterals
+      .filter(v => !UNDESIRED_LITERAL.includes(v))
+      .map(v => v == 'ORDER' ? 'ORDER BY' : v)
+      .map(v => v == 'GROUP' ? 'GROUP BY' : v)
+    this.addCandidatesforKeywords(keywords)
+  }
+
+  getColumnRefByPos(columns: ColumnRefNode[]) {
+    return columns.find(v =>
+      (v.location.start.line === this.pos.line + 1 && v.location.start.column <= this.pos.column) &&
+      (v.location.end.line === this.pos.line + 1 && v.location.end.column >= this.pos.column)
+    )
+  }
+
+  isPosInLocation(location: NodeRange) {
+    return (location.start.line === this.pos.line + 1 && location.start.column <= this.pos.column) &&
+      (location.end.line === this.pos.line + 1 && location.end.column >= this.pos.column)
+  }
+
+  /**
+   * Finds the most deeply nested FROM node that have a range encompasing the position.
+   * In cases such as SELECT * FROM T1 JOIN (SELECT * FROM (SELECT * FROM T2 <pos>))
+   * We will get a list of nodes like this
+   * SELECT * FROM T1
+   * (SELECT * FROM 
+   *    (SELECT * FROM T2))
+   * The idea is to reverse the list so that the most nested queries come first. Then
+   * apply a filter to keep only the FROM nodes which encompass the position and take
+   * the first one from that resulting list.
+   * @param fromNodes 
+   * @param pos 
+   * @returns 
+   */
+  getFromNodeByPos(fromNodes: FromTableNode[]) {
+    return fromNodes
+      .reverse()
+      .filter(tableNode => this.isPosInLocation(tableNode.location))
+      .shift()
+  }
+
+  /**
+   * Given a table returns all possible ways to refer to it.
+   * That is by table name only, using the database scope,
+   * using the catalog and database scopes.
+   * @param table 
+   * @returns 
+   */
+  allTableNameCombinations(table: Table): string[] {
+    const names = [table.tableName];
+    if (table.database) names.push(table.database + '.' + table.tableName)
+    if (table.catalog) names.push(table.catalog + '.' + table.database + '.' + table.tableName)
+    return names;
+  }
+
+  addCandidatesForTables(tables: Table[]) {
+    tables
+      .flatMap(table => this.allTableNameCombinations(table))
+      .map(aTableNameVariant => {
+        return new Identifier(
+          this.lastToken,
+          aTableNameVariant,
+          '',
+          TABLE_ICON
+        )
+      })
+      .filter(item => item.matchesLastToken())
+      .map(item => item.toCompletionItem())
+      .forEach(item => this.addCandidate(item))
+  }
+
+  addCandidatesForColumnsOfAnyTable(tables: Table[]) {
+    tables
+      .flatMap(table => table.columns)
+      .map(column => {
+        return new Identifier(
+          this.lastToken,
+          column.columnName,
+          column.description,
+          COLUMN_ICON
+        )
+      })
+      .filter(item => item.matchesLastToken())
+      .map(item => item.toCompletionItem())
+      .forEach(item => this.addCandidate(item))
+  }
+
+  addCandidate(item: CompletionItem) {
+    this.candidates.push(item)
+  }
+
+  addCandidateIfStartsWithLastToken(item: CompletionItem) {
+    if (item.label.startsWith(this.lastToken)) {
+      this.candidates.push(item)
     }
   }
-  return []
-}
 
-function completeSelectStatement(ast: SelectStatement, _pos: Pos, _tables: Table[]): CompletionItem[] {
-  let candidates: CompletionItem[] = []
-  if (Array.isArray(ast.columns)) {
-    const first = ast.columns[0]
-    const rest = ast.columns.slice(1, ast.columns.length)
-    const lastColumn = rest.reduce((p, c) => p.location.end.offset < c.location.end.offset ? c : p, first)
-    if (
-      (lastColumn.expr.type === 'column_ref' && FROM_KEYWORD.label.startsWith(lastColumn.expr.column)) ||
-      (lastColumn.as && FROM_KEYWORD.label.startsWith(lastColumn.as))
-    ) {
-      candidates.push(FROM_KEYWORD)
-    }
-    if (
-      (lastColumn.as && AS_KEYWORD.label.startsWith(lastColumn.as))
-    ) {
-      candidates.push(AS_KEYWORD)
+  addCandidatesForIncompleteSubquery(incompleteSubquery: IncompleteSubqueryNode) {
+    const parsedFromClause = getFromNodesFromClause(incompleteSubquery.text)
+    try {
+      parse(incompleteSubquery.text);
+    } catch (e) {
+      if (e.name !== 'SyntaxError') {
+        throw e
+      }
+      const fromText = incompleteSubquery.text
+      const newPos = parsedFromClause ? {
+        line: this.pos.line - (incompleteSubquery.location.start.line - 1),
+        column: this.pos.column - incompleteSubquery.location.start.column + 1
+      } : { line: 0, column: 0 }
+      const completer = new Completer(this.schema, fromText, newPos)
+      completer.complete().forEach(item => this.addCandidate(item))
     }
   }
-  return candidates
-}
 
-/**
- * Recursively pull out the FROM nodes (including sub-queries)
- * @param tableNodes
- * @returns 
- */
-function getAllNestedFromNodes(tableNodes: FromTableNode[]): FromTableNode[] {
-  return tableNodes.flatMap(tableNode => {
-    let result = [tableNode]
-    if (tableNode.type == 'subquery') {
-      const subTableNodes = tableNode.subquery.from?.tables || []
-      result = result.concat(getAllNestedFromNodes(subTableNodes))
+  createTablesFromFromNodes(fromNodes: FromTableNode[]): Table[] {
+    return fromNodes.reduce((p: any, c) => {
+      if (c.type !== 'subquery') {
+        return p
+      }
+      if (!Array.isArray(c.subquery.columns)) {
+        return p
+      }
+      const columns = c.subquery.columns.map(v => {
+        if (typeof v === 'string') { return null }
+        return { columnName: v.as || (v.expr.type === 'column_ref' && v.expr.column) || '', description: 'alias' }
+      })
+      return p.concat({ database: null, columns, tableName: c.as })
+    }, [])
+  }
+
+  /**
+   * INSERT INTO TABLE1 (C
+   */
+  addCandidatesForInsert() {
+    this.addCandidatesForColumnsOfAnyTable(this.schema.tables)
+  }
+
+  addCandidatesForError(e: any) {
+    this.addCandidatesForExpectedLiterals(e.expected || [])
+    this.addCandidatesForFunctions()
+    this.addCandidatesForTables(this.schema.tables)
+  }
+
+  addCandidatesForSelectQuery(e: any, fromNodes: FromTableNode[]) {
+    this.addCandidatesForExpectedLiterals(e.expected || [])
+    const subqueryTables = this.createTablesFromFromNodes(fromNodes)
+    const schemaAndSubqueries = this.schema.tables.concat(subqueryTables)
+    this.addCandidatesForFunctions()
+    this.addCandidatesForScopedColumns(fromNodes, schemaAndSubqueries)
+    this.addCandidatesForAliases(fromNodes)
+    this.addCandidatesForTables(schemaAndSubqueries)
+    if (logger.isDebugEnabled()) logger.debug(`candidates for error returns: ${JSON.stringify(this.candidates)}`)
+  }
+
+  getRidOfAfterCursorString() {
+    return this.sql.split('\n').filter((_v, idx) => this.pos.line >= idx).map((v, idx) => idx === this.pos.line ? v.slice(0, this.pos.column) : v).join('\n')
+  }
+
+  addCandidatesForParsedDeleteStatement(ast: DeleteStatement) {
+    if (this.isPosInLocation(ast.table.location)) {
+      this.addCandidatesForTables(this.schema.tables)
     }
-    return result
-  })
-}
-
-let lastToken = ''
-let candidates: CompletionItem[] = []
-
-export function complete(sql: string, pos: Pos, schema: Schema = { tables: [], functions: [] }) {
-  if (logger.isDebugEnabled()) logger.debug(`complete: ${sql}, ${JSON.stringify(pos)}`)
-  candidates = []
-  let error = null;
-
-  const target = getRidOfAfterCursorString(sql, pos)
-  logger.debug(`target: ${target}`)
-  lastToken = getLastToken(target)
-  try {
-    const ast = parse(target);
-    candidates = getCandidatesForParsedQuery(lastToken, sql, ast, schema, pos)
-  } catch (e) {
-    logger.debug('error')
-    logger.debug(e)
-    if (e.name !== 'SyntaxError') {
-      throw e
-    }
-    const parsedFromClause = getFromNodesFromClause(sql)
-    if (parsedFromClause) {
-      const fromNodes = getAllNestedFromNodes(parsedFromClause?.from?.tables || [])
-      const fromNodeOnCursor = getFromNodeByPos(fromNodes, pos)
-      if (fromNodeOnCursor && fromNodeOnCursor.type === 'incomplete_subquery') {
-        // Incomplete sub query 'SELECT sub FROM (SELECT e. FROM employees e) sub'
-        candidates = getCandidatesForIncompleteSubquery(fromNodeOnCursor, pos, schema)
-      } else {
-        candidates = getCandidatesForQuery(lastToken, schema, pos, e, fromNodes)
+    else if (ast.where && this.isPosInLocation(ast.where.expression.location)) {
+      const expr = ast.where.expression
+      if (expr.type === 'column_ref') {
+        this.addCandidatesForColumnsOfAnyTable(this.schema.tables)
       }
     }
-    else if (e.message === 'EXPECTED COLUMN NAME') {
-      candidates = getCandidatesForInsert(lastToken, schema)
-    }
-    else {
-      candidates = getCandidatesForError(lastToken, schema, e)
-    }
-    error = { label: e.name, detail: e.message, line: e.line, offset: e.offset }
   }
 
-  candidates = filterCandidatesUsingLastToken(lastToken, candidates, pos)
-  return { candidates, error }
-}
+  completeSelectStatement(ast: SelectStatement) {
+    if (Array.isArray(ast.columns)) {
+      this.addCandidateIfStartsWithLastToken(FROM_KEYWORD)
+      this.addCandidateIfStartsWithLastToken(AS_KEYWORD)
+    }
+  }
 
-function filterCandidatesUsingLastToken(lastToken: string, candidates: CompletionItem[], _pos: Pos): CompletionItem[] {
-  logger.debug(`filter based on lastToken: ${lastToken}`)
-  if (logger.isDebugEnabled()) logger.debug(`candidates are: ${JSON.stringify(candidates)}`)
-  return candidates
-    .filter(v => {
-      return v.label.startsWith(lastToken) || v.data?.matchesLastToken
+  /**
+   * Recursively pull out the FROM nodes (including sub-queries)
+   * @param tableNodes
+   * @returns 
+   */
+  getAllNestedFromNodes(tableNodes: FromTableNode[]): FromTableNode[] {
+    return tableNodes.flatMap(tableNode => {
+      let result = [tableNode]
+      if (tableNode.type == 'subquery') {
+        const subTableNodes = tableNode.subquery.from?.tables || []
+        result = result.concat(this.getAllNestedFromNodes(subTableNodes))
+      }
+      return result
     })
-}
+  }
 
-function getCandidatesForParsedQuery(lastToken: string, sql: string, ast: any, schema: Schema, pos: Pos): CompletionItem[] {
-  if (logger.isDebugEnabled()) logger.debug(`getting candidates for parse query ast: ${JSON.stringify(ast)}`)
-  if (!ast.type) {
-    return getBasicKeywordCandidates(lastToken)
-  }
-  if (ast.type === 'delete') {
-    return completeDeleteStatement('', ast, pos, schema.tables)
-  }
-  else if (ast.type === 'select') {
-    let candidates = getBasicKeywordCandidates(lastToken)
-    candidates = candidates.concat(completeSelectStatement(ast, pos, schema.tables))
+  addCandidatesForParsedSelectQuery(ast: any) {
+    this.addCandidatesForBasicKeyword()
+    this.completeSelectStatement(ast)
     if (!ast.distinct) {
-      candidates.push(DISTINCT_KEYWORD)
+      this.addCandidateIfStartsWithLastToken(DISTINCT_KEYWORD)
     }
-    const columnRef = getColumnAtPosition(ast, pos)
+    const columnRef = this.findColumnAtPosition(ast)
     if (!columnRef) {
-      candidates = candidates.concat(getJoinCondidates(ast, schema, pos))
+      this.addJoinCondidates(ast)
     }
     else {
-      const parsedFromClause = getFromNodesFromClause(sql)
+      const parsedFromClause = getFromNodesFromClause(this.sql)
       const fromNodes = parsedFromClause?.from?.tables || []
-      const subqueryTables = createTablesFromFromNodes(fromNodes)
-      const schemaAndSubqueries = schema.tables.concat(subqueryTables)
+      const subqueryTables = this.createTablesFromFromNodes(fromNodes)
+      const schemaAndSubqueries = this.schema.tables.concat(subqueryTables)
       if (columnRef.table) {
         // We know what table/alias this column belongs to
-        const partialColumnName = columnRef.column
-        const tableOrAlias = columnRef.table
-        // Strip out any subscripts t.abc[0].xyz
-        const lastToken2 = getLastToken(' ' + tableOrAlias + '.' + partialColumnName)
         // Find the corresponding table and suggest it's columns
-        candidates = candidates.concat(
-          getScopedColumnCandidates(lastToken2, fromNodes, schemaAndSubqueries))
+        this.addCandidatesForScopedColumns(fromNodes, schemaAndSubqueries)
       }
       else {
         // Column is not scoped to a table/alias yet
-        const lastToken2 = columnRef.column
         // Could be an alias, a talbe or a function
-        candidates = candidates.concat(
-          getAliasCandidates(lastToken2, fromNodes),
-          getTableCandidates(lastToken2, schemaAndSubqueries),
-
-          //getSelectTableCondidates(partialName, schema.tables),
-          getFunctionCondidates(lastToken2, schema.functions))
+        this.addCandidatesForAliases(fromNodes)
+        this.addCandidatesForTables(schemaAndSubqueries)
+        this.addCandidatesForFunctions()
       }
     }
-    if (logger.isDebugEnabled()) logger.debug(`parse query returns: ${JSON.stringify(candidates)}`)
-    return candidates
+    if (logger.isDebugEnabled()) logger.debug(`parse query returns: ${JSON.stringify(this.candidates)}`)
   }
-  else {
-    console.log(`AST type not supported yet: ${ast.type}`)
-    return []
+
+  addCandidatesForParsedStatement(ast: any) {
+    if (logger.isDebugEnabled()) logger.debug(`getting candidates for parse query ast: ${JSON.stringify(ast)}`)
+    if (!ast.type) {
+      this.addCandidatesForBasicKeyword()
+    }
+    else if (ast.type === 'delete') {
+      this.addCandidatesForParsedDeleteStatement(ast)
+    }
+    else if (ast.type === 'select') {
+      this.addCandidatesForParsedSelectQuery(ast)
+    }
+    else {
+      console.log(`AST type not supported yet: ${ast.type}`)
+    }
   }
-}
-function makeLastToken(fromTable: any): string {
-  const parts = []
-  if (fromTable.catalog) parts.push(fromTable.catalog)
-  if (fromTable.db) parts.push(fromTable.db)
-  if (fromTable.table) parts.push(fromTable.table)
-  return parts.join('.')
-}
 
-
-
-function getJoinCondidates(ast: any, schema: Schema, pos: Pos): CompletionItem[] {
-  // from clause: complete 'ON' keyword on 'INNER JOIN'
-  if (ast.type === 'select' && Array.isArray(ast.from?.tables)) {
-    const fromTable = getFromNodeByPos(ast.from?.tables || [], pos)
-    if (fromTable && fromTable.type === 'table') {
-      const lastToken = makeLastToken(fromTable)
-      const candidates = getTableCandidates(lastToken, schema.tables)
-      candidates.push(INNERJOIN_KEYWORD, LEFTJOIN_KEYWORD)
-      // = candidates.concat([{ label: 'INNER JOIN' }, { label: 'LEFT JOIN' }])
-      if (fromTable.join && !fromTable.on) {
-        candidates.push(ON_KEYWORD)
+  addJoinCondidates(ast: any) {
+    // from clause: complete 'ON' keyword on 'INNER JOIN'
+    if (ast.type === 'select' && Array.isArray(ast.from?.tables)) {
+      const fromTable = this.getFromNodeByPos(ast.from?.tables || [])
+      if (fromTable && fromTable.type === 'table') {
+        this.addCandidatesForTables(this.schema.tables)
+        this.addCandidateIfStartsWithLastToken(INNERJOIN_KEYWORD)
+        this.addCandidateIfStartsWithLastToken(LEFTJOIN_KEYWORD)
+        if (fromTable.join && !fromTable.on) {
+          this.addCandidateIfStartsWithLastToken(ON_KEYWORD)
+        }
       }
-      return candidates
     }
   }
-  return []
-}
 
-function getColumnAtPosition(ast: any, pos: Pos): ColumnRefNode | undefined {
-  const columns = ast.columns
-  if (Array.isArray(columns)) {
-    // columns in select clause
-    const columnRefs = (columns as any).map((col: any) => col.expr).filter((expr: any) => !!expr)
-    if (ast.type === 'select' && ast.where?.expression) {
-      // columns in where clause  
-      columnRefs.push(ast.where.expression)
+  findColumnAtPosition(ast: any): ColumnRefNode | undefined {
+    const columns = ast.columns
+    if (Array.isArray(columns)) {
+      // columns in select clause
+      const columnRefs = (columns as any).map((col: any) => col.expr).filter((expr: any) => !!expr)
+      if (ast.type === 'select' && ast.where?.expression) {
+        // columns in where clause  
+        columnRefs.push(ast.where.expression)
+      }
+      // column at position
+      const columnRef = this.getColumnRefByPos(columnRefs)
+      if (logger.isDebugEnabled()) logger.debug(JSON.stringify(columnRef))
+      return columnRef
     }
-    // column at position
-    const columnRef = getColumnRefByPos(columnRefs, pos)
-    if (logger.isDebugEnabled()) logger.debug(JSON.stringify(columnRef))
-    return columnRef
+    return undefined
   }
-  return undefined
-}
 
-function toCompletionItemFromFunction(f: DbFunction): CompletionItem {
-  return {
-    label: f.name,
-    detail: 'function',
-    kind: FUNCTION_ICON,
-    documentation: f.description,
-    data: { matchesLastToken: true },
-  }
-}
-
-function toCompletionItemForAlias(alias: string): CompletionItem {
-  return {
-    label: alias,
-    detail: 'alias',
-    kind: ALIAS_ICON,
-    data: { matchesLastToken: true },
-  }
-}
-
-type Identifier = {
-  lastToken: string,
-  identifier: string,
-  detail: string,
-  kind: CompletionItemKind
-}
-
-function toCompletionItemIdentifierStartsWith(item: Identifier): CompletionItem {
-  const kindName = item.kind == TABLE_ICON ? 'table' : 'column'
-  const matchesLastToken = item.identifier.startsWith(item.lastToken);
-  if (item.lastToken.indexOf('.') > 0) {
-    const remainingNamePart = item.identifier.substr(item.lastToken.lastIndexOf('.') + 1)
-    return {
-      label: remainingNamePart,
-      filterText: '.' + remainingNamePart,
-      insertText: '.' + remainingNamePart,
-      detail: `${kindName} ${item.detail}`,
-      kind: item.kind,
-      data: { matchesLastToken: matchesLastToken },
+  addCandidatesForFunctions() {
+    if (!this.lastToken) {
+      // Nothing was typed, return all lowercase functions
+      this.schema.functions
+        .map(func => toCompletionItemForFunction(func))
+        .forEach(item => this.addCandidate(item))
     }
-  }
-  else {
-    return {
-      label: item.identifier,
-      detail: `${kindName} ${item.identifier}`,
-      kind: item.kind,
-      data: { matchesLastToken: matchesLastToken },
-    }
-  }
-}
-
-function getFunctionCondidates(prefix: string, functions: DbFunction[]): CompletionItem[] {
-  if (!prefix) {
-    // Nothing was typed, return all lowercase functions
-    return functions.map(v => toCompletionItemFromFunction(v))
-  }
-  else {
-    // If user typed the start of the function
-    const lower = prefix.toLowerCase()
-    const isTypedUpper = (prefix != lower)
-    return functions
-      // Search using lowercase prefix
-      .filter(v => v.name.startsWith(lower))
-      // If typed string is in upper case, then return upper case suggestions
-      .map(v => {
-        if (isTypedUpper) v.name = v.name.toUpperCase()
-        return v
-      })
-      .map(v => toCompletionItemFromFunction(v))
-  }
-
-}
-
-function makeColumnName(alias: string, columnName: string) {
-  if (alias) {
-    return alias + '.' + columnName;
-  }
-  return columnName;
-}
-
-function getScopedColumnCandidates(lastToken: string, fromNodes: FromTableNode[], tables: Table[]): CompletionItem[] {
-  return tables.flatMap(table => {
-    return fromNodes.filter((fromNode: any) => tableMatch(fromNode, table))
-      .map((fromNode: any) => fromNode.as || fromNode.table)
-      .filter(alias => lastToken.startsWith(alias + '.')
-      )
-      .flatMap(alias =>
-        table.columns.map(col => {
-          return {
-            lastToken: lastToken,
-            identifier: makeColumnName(alias, col.columnName),
-            detail: col.description,
-            kind: COLUMN_ICON
-          }
+    else {
+      // If user typed the start of the function
+      const lower = this.lastToken.toLowerCase()
+      const isTypedUpper = (this.lastToken != lower)
+      this.schema.functions
+        // Search using lowercase prefix
+        .filter(v => v.name.startsWith(lower))
+        // If typed string is in upper case, then return upper case suggestions
+        .map(v => {
+          if (isTypedUpper) v.name = v.name.toUpperCase()
+          return v
         })
-      )
-      .map(item => toCompletionItemIdentifierStartsWith(item))
-  })
+        .map(v => toCompletionItemForFunction(v))
+        .forEach(item => this.addCandidate(item))
+    }
+  }
+
+  makeColumnName(alias: string, columnName: string) {
+    return alias ? alias + '.' + columnName : columnName;
+  }
+
+  addCandidatesForScopedColumns(fromNodes: FromTableNode[], tables: Table[]) {
+    tables.flatMap(table => {
+      return fromNodes.filter((fromNode: any) => this.tableMatch(fromNode, table))
+        .map((fromNode: any) => fromNode.as || fromNode.table)
+        .filter(alias => this.lastToken.startsWith(alias + '.'))
+        .flatMap(alias =>
+          table.columns.map(col => {
+            return new Identifier(
+              this.lastToken,
+              this.makeColumnName(alias, col.columnName),
+              col.description,
+              COLUMN_ICON
+            )
+          })
+        )
+    })
+      .filter(item => item.matchesLastToken())
+      .map(item => item.toCompletionItem())
+      .forEach(item => this.addCandidate(item))
+  }
+
+  /**
+   * Test if the given table matches the fromNode.
+   * @param fromNode 
+   * @param table 
+   * @returns 
+   */
+  tableMatch(fromNode: any, table: Table) {
+    // Assume table matches from node and disprove
+    let matchingTable = true
+    if (fromNode.type == 'subquery') {
+      // If we have an alias it should match the subquery table name
+      if (fromNode.as && fromNode.as != table.tableName) {
+        matchingTable = false;
+      }
+    }
+    // Regular tables
+    // If we have a from node with a table name
+    // and it does not match the table, we know it's not a match 
+    else {
+      if (fromNode.table && fromNode.table != table.tableName) {
+        matchingTable = false;
+      }
+      else if (fromNode.db && fromNode.db != table.database) {
+        matchingTable = false;
+      }
+      else if (fromNode.catalog && fromNode.catalog != table.catalog) {
+        matchingTable = false;
+      }
+    }
+    return matchingTable;
+  }
+
+  addCandidatesForAliases(fromNodes: FromTableNode[]) {
+    fromNodes
+      .map((fromNode: any) => fromNode.as)
+      .filter(aliasName => aliasName && aliasName.startsWith(this.lastToken))
+      .map(aliasName => toCompletionItemForAlias(aliasName))
+      .forEach(item => this.addCandidate(item))
+  }
 }
 
-function tableMatch(fromNode: any, table: Table) {
-  if (fromNode.type == 'subquery' &&
-    fromNode.as &&
-    fromNode.as != table.tableName) {
-    return false;
-  }
-  else if (fromNode.table && fromNode.table != table.tableName) {
-    return false;
-  }
-  else if (fromNode.db && fromNode.db != table.database) {
-    return false;
-  }
-  else if (fromNode.catalog && fromNode.catalog != table.catalog) {
-    return false;
-  }
-  return true;
-}
 
-function getAliasCandidates(lastToken: string, fromNodes: FromTableNode[]): CompletionItem[] {
-  return fromNodes
-    .map((fromNode: any) => fromNode.as)
-    .filter(aliasName => aliasName && aliasName.startsWith(lastToken))
-    .map(aliasName => toCompletionItemForAlias(aliasName))
+export function complete(sql: string, pos: Pos, schema: Schema = { tables: [], functions: [] }) {
+  if (logger.isDebugEnabled()) logger.debug(`complete: ${sql}, ${JSON.stringify(pos)}`)
+  const completer = new Completer(schema, sql, pos)
+  const candidates = completer.complete()
+  return { candidates: candidates, error: completer.error }
 }

--- a/packages/server/src/createServer.ts
+++ b/packages/server/src/createServer.ts
@@ -8,7 +8,7 @@ import * as VscodeNode  from 'vscode-languageserver/node'
 import { TextDocument } from 'vscode-languageserver-textdocument' 
 import { CodeAction, TextDocumentEdit, TextEdit, Position, CodeActionKind } from 'vscode-languageserver-types'
 import cache from './cache'
-import complete from './complete'
+import { complete } from './complete'
 import createDiagnostics from './createDiagnostics'
 import createConnection from './createConnection'
 import yargs from 'yargs'
@@ -198,11 +198,9 @@ export function createServerWithConnection(connection: Connection) {
       return []
     }
     logger.debug(text || '')
-    const candidates = complete(text, {
-  		line: docParams.position.line,
-  		column: docParams.position.character
-  	}, schema).candidates
-  	logger.debug(candidates.map(v => v.label).join(","))
+    let pos = { line: docParams.position.line, column: docParams.position.character }
+    const candidates = complete(text, pos, schema).candidates
+    if (logger.isDebugEnabled()) logger.debug('onCompletion returns: ' + JSON.stringify(candidates))
     return candidates
   })
 

--- a/packages/server/src/createServer.ts
+++ b/packages/server/src/createServer.ts
@@ -7,7 +7,7 @@ import {
 } from 'vscode-languageserver/node'
 import * as VscodeNode from 'vscode-languageserver/node'
 import { TextDocument } from 'vscode-languageserver-textdocument'
-import { CodeAction, TextDocumentEdit, TextEdit, Position, CodeActionKind, WorkspaceEdit } from 'vscode-languageserver-types'
+import { CodeAction, TextDocumentEdit, TextEdit, Position, CodeActionKind } from 'vscode-languageserver-types'
 import cache from './cache'
 import { complete } from './complete'
 import createDiagnostics from './createDiagnostics'

--- a/packages/server/src/createServer.ts
+++ b/packages/server/src/createServer.ts
@@ -48,7 +48,7 @@ export function createServerWithConnection(connection: Connection) {
       schema = JSON.parse(data);
     }
     catch (e) {
-      logger.error("failed to read schema file")
+      logger.error("failed to read schema file " + e.message)
       connection.sendNotification('sqlLanguageServer.error', {
         message: "Failed to read schema file: " + filePath + " error: " + e.message
       })
@@ -57,11 +57,13 @@ export function createServerWithConnection(connection: Connection) {
   }
 
   function readAndMonitorJsonSchemaFile(filePath: string) {
-    readJsonSchemaFile(filePath)
     fs.watchFile(filePath, (_curr, _prev) => {
       logger.info(`change detected, reloading schema file: ${filePath}`)
       readJsonSchemaFile(filePath)
     })
+    // The readJsonSchemaFile function can throw exceptions so
+    // read file only after setting up monitoring
+    readJsonSchemaFile(filePath)
   }
 
   async function makeDiagnostics(document: TextDocument) {

--- a/packages/server/src/database_libs/AbstractClient.ts
+++ b/packages/server/src/database_libs/AbstractClient.ts
@@ -17,6 +17,7 @@ export type Column = {
   description: string
 }
 export type Table = {
+  catalog: string | null,
   database: string | null,
   tableName: string,
   columns: Column[]
@@ -74,6 +75,7 @@ export default abstract class AbstractClient {
       const tables = await this.getTables()
       schema.tables = await Promise.all(
         tables.map((v) => this.getColumns(v).then(columns => ({
+          catalog: null,
           database: this.settings.database,
           tableName: v,
           columns: columns.map(v => this.toColumnFromRawField(v)) }

--- a/packages/server/test/complete.test.ts
+++ b/packages/server/test/complete.test.ts
@@ -1,4 +1,4 @@
-import {complete, getLastToken} from '../src/complete'
+import {complete, getLastToken, Identifier, COLUMN_ICON} from '../src/complete'
 
 describe('keyword completion', () => {
   test("complete 'SELECT' keyword", () => {
@@ -920,3 +920,55 @@ describe('DELETE statement', () => {
     expect(result.candidates[1].label).toEqual('COLUMN2')
   })
 })
+
+describe('toCompletionItemForIdentifier', () => {
+  test('complete comlumn name', () => {
+    const item = new Identifier(
+      'col',
+      'column1',
+      '',
+      COLUMN_ICON
+    )
+    const completion = item.toCompletionItem()
+    expect(completion.label).toEqual('column1')
+    expect(completion.insertText).toEqual('column1')
+    expect(completion.filterText).toEqual('column1')
+  })
+  test('complete aliased comlumn name', () => {
+    const item = new Identifier(
+      'ali.col',
+      'ali.column1',
+      '',
+      COLUMN_ICON
+    )
+    const completion = item.toCompletionItem()
+    expect(completion.label).toEqual('column1')
+    expect(completion.insertText).toEqual('.column1')
+    expect(completion.filterText).toEqual('.column1')
+  })
+  test('complete aliased nested comlumn name', () => {
+    const item = new Identifier(
+      'ali.column1.sub',
+      'ali.column1.subcolumn2',
+      '',
+      COLUMN_ICON
+    )
+    const completion = item.toCompletionItem()
+    expect(completion.label).toEqual('subcolumn2')
+    expect(completion.insertText).toEqual('.subcolumn2')
+    expect(completion.filterText).toEqual('.subcolumn2')
+  })
+  test('complete aliased nested comlumn name2', () => {
+    const item = new Identifier(
+      'ali.colu',
+      'ali.column1.subcolumn2',
+      '',
+      COLUMN_ICON
+    )
+    const completion = item.toCompletionItem()
+    expect(completion.label).toEqual('column1.subcolumn2')
+    expect(completion.insertText).toEqual('.column1.subcolumn2')
+    expect(completion.filterText).toEqual('.column1.subcolumn2')
+  })
+})
+

--- a/packages/server/test/complete.test.ts
+++ b/packages/server/test/complete.test.ts
@@ -205,8 +205,8 @@ describe('ColumnName completion', () => {
     const result = complete('SELECT TABLE1.C FROM TABLE1', { line: 0, column: 15 }, SIMPLE_SCHEMA)
     expect(result.candidates.length).toEqual(2)
     let expected = [
-      expect.objectContaining({ label: 'COLUMN1', insertText: '.COLUMN1' }),
-      expect.objectContaining({ label: 'COLUMN2', insertText: '.COLUMN2' }),
+      expect.objectContaining({ label: 'COLUMN1' }),
+      expect.objectContaining({ label: 'COLUMN2' }),
     ]
     expect(result.candidates).toEqual(expect.arrayContaining(expected))
   })
@@ -521,9 +521,9 @@ describe('Nested ColumnName completion', () => {
     const result = complete('SELECT TABLE1.a FROM TABLE1', { line: 0, column: 15 }, SIMPLE_NESTED_SCHEMA)
     expect(result.candidates.length).toEqual(3)
     let expected = [
-      expect.objectContaining({ label: 'abc', insertText: '.abc' }),
-      expect.objectContaining({ label: 'abc.def', insertText: '.abc.def' }),
-      expect.objectContaining({ label: 'abc.def.ghi', insertText: '.abc.def.ghi' }),
+      expect.objectContaining({ label: 'abc' }),
+      expect.objectContaining({ label: 'abc.def' }),
+      expect.objectContaining({ label: 'abc.def.ghi' }),
     ]
     expect(result.candidates).toEqual(expect.arrayContaining(expected))
   })
@@ -542,8 +542,8 @@ describe('Nested ColumnName completion', () => {
     const result = complete('SELECT TABLE1.abc.d FROM TABLE1', { line: 0, column: 19 }, SIMPLE_NESTED_SCHEMA)
     expect(result.candidates.length).toEqual(2)
     let expected = [
-      expect.objectContaining({ label: 'def', insertText: '.def' }),
-      expect.objectContaining({ label: 'def.ghi', insertText: '.def.ghi' }),
+      expect.objectContaining({ label: 'def' }),
+      expect.objectContaining({ label: 'def.ghi' }),
     ]
     expect(result.candidates).toEqual(expect.arrayContaining(expected))
   })
@@ -566,8 +566,6 @@ describe('Nested ColumnName completion', () => {
     expect(result.candidates.length).toEqual(2)
     expect(result.candidates[0].label).toEqual('def')
     expect(result.candidates[1].label).toEqual('def.ghi')
-    expect(result.candidates[0].insertText).toEqual('.def')
-    expect(result.candidates[1].insertText).toEqual('.def.ghi')
   })
 
   test("complete ColumnName:cursor on first char:using alias", () => {
@@ -575,8 +573,6 @@ describe('Nested ColumnName completion', () => {
     expect(result.candidates.length).toEqual(2)
     expect(result.candidates[0].label).toEqual('def')
     expect(result.candidates[1].label).toEqual('def.ghi')
-    expect(result.candidates[0].insertText).toEqual('.def')
-    expect(result.candidates[1].insertText).toEqual('.def.ghi')
   })
 
   test("complete ColumnName with space:cursor on first char", () => {
@@ -584,8 +580,6 @@ describe('Nested ColumnName completion', () => {
     expect(result.candidates.length).toEqual(2)
     expect(result.candidates[0].label).toEqual('`with spaces`')
     expect(result.candidates[1].label).toEqual('`with spaces`.`sub space`')
-    expect(result.candidates[0].insertText).toEqual('.`with spaces`')
-    expect(result.candidates[1].insertText).toEqual('.`with spaces`.`sub space`')
   })
 
   test("getLastToken", () => {
@@ -620,8 +614,6 @@ describe('Nested ColumnName completion', () => {
     expect(result.candidates.length).toEqual(2)
     expect(result.candidates[0].label).toEqual('def')
     expect(result.candidates[1].label).toEqual('def.ghi')
-    expect(result.candidates[0].insertText).toEqual('.def')
-    expect(result.candidates[1].insertText).toEqual('.def.ghi')
   })
 
   test("with map subscripted", () => {
@@ -638,8 +630,6 @@ describe('Nested ColumnName completion', () => {
     expect(result.candidates.length).toEqual(2)
     expect(result.candidates[0].label).toEqual("def")
     expect(result.candidates[1].label).toEqual("def.ghi")
-    expect(result.candidates[0].insertText).toEqual(".def")
-    expect(result.candidates[1].insertText).toEqual(".def.ghi")
   })
 })
 
@@ -825,7 +815,6 @@ test("complete aliased column inside function", () => {
   const result = complete(sql, { line: 0, column: 24 }, COMPLEX_SCHEMA)
   expect(result.candidates.length).toEqual(1)
   expect(result.candidates[0].label).toEqual('department_id')
-  expect(result.candidates[0].insertText).toEqual('.department_id')
 })
 
 test("complete column inside function", () => {
@@ -833,7 +822,6 @@ test("complete column inside function", () => {
   const result = complete(sql, { line: 0, column: 19 }, COMPLEX_SCHEMA)
   expect(result.candidates.length).toEqual(1)
   expect(result.candidates[0].label).toEqual('employees')
-  //expect(result.candidates[0].insertText).toEqual('oyees')
 })
 
 test("complete an alias inside function", () => {
@@ -841,7 +829,6 @@ test("complete an alias inside function", () => {
   const result = complete(sql, { line: 0, column: 21 }, COMPLEX_SCHEMA)
   expect(result.candidates.length).toEqual(1)
   expect(result.candidates[0].label).toEqual('an_alias')
-  //expect(result.candidates[0].insertText).toEqual('as')
 })
 
 describe('From clause subquery', () => {
@@ -932,8 +919,8 @@ describe('toCompletionItemForIdentifier', () => {
     )
     const completion = item.toCompletionItem()
     expect(completion.label).toEqual('column1')
-    expect(completion.insertText).toEqual('column1')
-    expect(completion.filterText).toEqual('column1')
+    expect(completion.insertText).toBeUndefined()
+    expect(completion.filterText).toBeUndefined()
   })
   test('complete aliased comlumn name', () => {
     const item = new Identifier(
@@ -944,8 +931,8 @@ describe('toCompletionItemForIdentifier', () => {
     )
     const completion = item.toCompletionItem()
     expect(completion.label).toEqual('column1')
-    expect(completion.insertText).toEqual('.column1')
-    expect(completion.filterText).toEqual('.column1')
+    expect(completion.insertText).toBeUndefined()
+    expect(completion.filterText).toBeUndefined()
   })
   test('complete aliased nested comlumn last part name', () => {
     const item = new Identifier(
@@ -956,8 +943,8 @@ describe('toCompletionItemForIdentifier', () => {
     )
     const completion = item.toCompletionItem()
     expect(completion.label).toEqual('subcolumn2')
-    expect(completion.insertText).toEqual('.subcolumn2')
-    expect(completion.filterText).toEqual('.subcolumn2')
+    expect(completion.insertText).toBeUndefined()
+    expect(completion.filterText).toBeUndefined()
   })
   test('complete aliased nested comlumn first part name', () => {
     const item = new Identifier(
@@ -968,8 +955,22 @@ describe('toCompletionItemForIdentifier', () => {
     )
     const completion = item.toCompletionItem()
     expect(completion.label).toEqual('column1.subcolumn2')
-    expect(completion.insertText).toEqual('.column1.subcolumn2')
-    expect(completion.filterText).toEqual('.column1.subcolumn2')
+    expect(completion.insertText).toBeUndefined()
+    expect(completion.filterText).toBeUndefined()
   })
+
+  test('complete aliased nested comlumn (last char is a dot)', () => {
+    const item = new Identifier(
+      'ali.column1.',
+      'ali.column1.subcolumn2',
+      '',
+      COLUMN_ICON
+    )
+    const completion = item.toCompletionItem()
+    expect(completion.label).toEqual('subcolumn2')
+    expect(completion.insertText).toEqual('.subcolumn2')
+    expect(completion.filterText).toEqual('.subcolumn2')
+  })
+
 })
 

--- a/packages/server/test/complete.test.ts
+++ b/packages/server/test/complete.test.ts
@@ -1,4 +1,4 @@
-import complete from '../src/complete'
+import {complete, getLastToken} from '../src/complete'
 
 describe('keyword completion', () => {
   test("complete 'SELECT' keyword", () => {
@@ -6,7 +6,7 @@ describe('keyword completion', () => {
     expect(result.candidates.length).toEqual(1)
     expect(result.candidates[0].label).toEqual('SELECT')
   })
-  
+
   describe('FROM keyword', () => {
     test("complete FROM word with the star column", () => {
       const result = complete('SELECT * F', { line: 0, column: 10 })
@@ -15,10 +15,26 @@ describe('keyword completion', () => {
     })
 
     test("complete FROM word with norm columns", () => {
-      const sql = 'SELECT d, f F'
-      const result = complete('SELECT d, f F', { line: 0, column: sql.length })
+      const result = complete('SELECT d, f F', { line: 0, column: 13 })
       expect(result.candidates.length).toEqual(1)
       expect(result.candidates[0].label).toEqual('FROM')
+    })
+
+    test("complete FROM word with norm columns", () => {
+      const result = complete('SELECT d, f AS F', { line: 0, column: 16 })
+      // TODO: this is not correct but difficult to fix...
+      expect(result.candidates.length).toEqual(1)
+      expect(result.candidates[0].label).toEqual('FROM')
+    })
+    test("complete FROM word with norm columns", () => {
+      const result = complete('SELECT d, f AS aa F', { line: 0, column: 19 })
+      expect(result.candidates.length).toEqual(1)
+      expect(result.candidates[0].label).toEqual('FROM')
+    })
+    test("complete FROM word with norm columns", () => {
+      const result = complete('SELECT d, f A', { line: 0, column: 13 })
+      expect(result.candidates.length).toEqual(1)
+      expect(result.candidates[0].label).toEqual('AS')
     })
   })
 
@@ -28,7 +44,28 @@ describe('keyword completion', () => {
     expect(result.candidates[0].label).toEqual('WHERE')
   })
   
-  
+  test("complete 'WHERE' keyword one space", () => {
+    const result = complete('SELECT * FROM FOO AS foo W', { line: 0, column: 26 })
+    expect(result.candidates.length).toEqual(1)
+    expect(result.candidates[0].label).toEqual('WHERE')
+  })
+
+  test("complete 'WHERE' keyword two spaces", () => {
+    const result = complete('SELECT * FROM FOO AS foo  W', { line: 0, column: 27 })
+    expect(result.candidates.length).toEqual(1)
+    expect(result.candidates[0].label).toEqual('WHERE')
+  })
+
+  test("complete 'WHERE' keyword multi-line", () => {
+    const result = complete(`
+    SELECT * 
+    FROM FOO AS foo
+    W
+    `, { line: 3, column: 5 })
+    expect(result.candidates.length).toEqual(1)
+    expect(result.candidates[0].label).toEqual('WHERE')
+  })
+
   test("complete 'DISTINCT' keyword", () => {
     const result = complete('SELECT D', { line: 0, column: 9 })
     expect(result.candidates.length).toEqual(1)
@@ -83,54 +120,142 @@ describe('keyword completion', () => {
 })
 
 const SIMPLE_SCHEMA = {
-functions: [],
-tables: [
-  {
-    database: null,
-    tableName: 'TABLE1',
-    columns: [
-      { columnName: 'COLUMN1', description: '' },
-      { columnName: 'COLUMN2', description: '' }
-    ]
-  }
-]
+  tables: [
+    {
+      database: null,
+      tableName: 'TABLE1',
+      columns: [
+        { columnName: 'COLUMN1', description: '' },
+        { columnName: 'COLUMN2', description: '' }
+      ]
+    }
+  ],
+  functions: [
+    {
+      name: 'array_concat()',
+      description: 'desc1'
+    },
+    {
+      name: 'array_contains()',
+      description: 'desc2'
+    }
+  ]
 }
 
+describe('on blank space', () => {
+  test("complete ", () => {
+    const result = complete('', { line: 0, column: 0 }, SIMPLE_SCHEMA)
+    expect(result.candidates.length).toEqual(8)
+    let expected = [
+      expect.objectContaining({ label: 'SELECT' }),
+      expect.objectContaining({ label: 'WHERE' }),
+      expect.objectContaining({ label: 'ORDER BY' }),
+      expect.objectContaining({ label: 'GROUP BY' }),
+      expect.objectContaining({ label: 'LIMIT' }),
+      expect.objectContaining({ label: '--' }),
+      expect.objectContaining({ label: '/*' }),
+      expect.objectContaining({ label: '(' }),
+    ]
+    expect(result.candidates).toEqual(expect.arrayContaining(expected))
+  })
+
+  test("complete inside SELECT", () => {
+    const result = complete('SELECT ', { line: 0, column: 7 }, SIMPLE_SCHEMA)
+    expect(result.candidates.length).toEqual(24) // TODO whare are they?
+    expect(result.candidates[22].label).toEqual('array_concat()')
+    expect(result.candidates[23].label).toEqual('array_contains()')
+  })
+})
+
 describe('TableName completion', () => {
+  test("complete function keyword", () => {
+    const result = complete('SELECT arr', { line: 0, column: 10 }, SIMPLE_SCHEMA)
+    expect(result.candidates.length).toEqual(2)
+    expect(result.candidates[0].label).toEqual('array_concat()')
+    expect(result.candidates[1].label).toEqual('array_contains()')
+  })
+
+  test("complete function keyword", () => {
+    const result = complete('SELECT ARR', { line: 0, column: 10 }, SIMPLE_SCHEMA)
+    expect(result.candidates.length).toEqual(2)
+    expect(result.candidates[0].label).toEqual('ARRAY_CONCAT()')
+    expect(result.candidates[1].label).toEqual('ARRAY_CONTAINS()')
+  })
+
   test("complete TableName", () => {
-    const result = complete( 'SELECT T FROM TABLE1', { line: 0, column: 8 }, SIMPLE_SCHEMA)
+    const result = complete('SELECT T FROM TABLE1', { line: 0, column: 8 }, SIMPLE_SCHEMA)
     expect(result.candidates.length).toEqual(1)
     expect(result.candidates[0].label).toEqual('TABLE1')
+  })
+  test("complete TableName", () => {
+    const result = complete('SELECT ta FROM TABLE1 as tab', { line: 0, column: 9 }, SIMPLE_SCHEMA)
+    expect(result.candidates.length).toEqual(1)
+    expect(result.candidates[0].label).toEqual('tab')
   })
 })
 
 describe('ColumnName completion', () => {
+  test("complete column name", () => {
+    const result = complete('SELECT COL FROM TABLE1', { line: 0, column: 10 }, SIMPLE_SCHEMA)
+    expect(result.candidates.length).toEqual(0)
+  })
+
   test("complete ColumnName", () => {
-    const result = complete( 'SELECT TABLE1.C FROM TABLE1', { line: 0, column: 15 }, SIMPLE_SCHEMA)
+    const result = complete('SELECT TABLE1.C FROM TABLE1', { line: 0, column: 15 }, SIMPLE_SCHEMA)
+    expect(result.candidates.length).toEqual(2)
+    let expected = [
+      expect.objectContaining({ label: 'COLUMN1', insertText: '.COLUMN1' }),
+      expect.objectContaining({ label: 'COLUMN2', insertText: '.COLUMN2' }),
+    ]
+    expect(result.candidates).toEqual(expect.arrayContaining(expected))
+  })
+
+  test("complete ColumnName with previous back tick column", () => {
+    const result = complete('SELECT `COLUMN2`, TABLE1.C FROM TABLE1', { line: 0, column: 26 }, SIMPLE_SCHEMA)
     expect(result.candidates.length).toEqual(2)
     expect(result.candidates[0].label).toEqual('COLUMN1')
     expect(result.candidates[1].label).toEqual('COLUMN2')
   })
-  
+
   test("complete ColumnName: cursor on dot", () => {
     const result = complete('SELECT TABLE1. FROM TABLE1', { line: 0, column: 14 }, SIMPLE_SCHEMA)
     expect(result.candidates.length).toEqual(2)
     expect(result.candidates[0].label).toEqual('COLUMN1')
     expect(result.candidates[1].label).toEqual('COLUMN2')
   })
-  
+
   test("complete ColumnName:cursor on dot:multi line", () => {
-    const result = complete( 'SELECT *\nFROM TABLE1\nWHERE TABLE1.', { line: 2, column: 13 }, SIMPLE_SCHEMA)
+    const result = complete('SELECT *\nFROM TABLE1\nWHERE TABLE1.', { line: 2, column: 13 }, SIMPLE_SCHEMA)
     expect(result.candidates.length).toEqual(2)
     expect(result.candidates[0].label).toEqual('COLUMN1')
     expect(result.candidates[1].label).toEqual('COLUMN2')
   })
-  
+
   test("complete ColumnName:cursor on dot:using alias", () => {
     const result = complete('SELECT *\nFROM TABLE1 t\nWHERE t.', { line: 2, column: 8 }, SIMPLE_SCHEMA)
     expect(result.candidates.length).toEqual(2)
     expect(result.candidates[0].label).toEqual('COLUMN1')
     expect(result.candidates[1].label).toEqual('COLUMN2')
+  })
+
+  test("complete ColumnName:cursor on dot:using alias", () => {
+    const result = complete('SELECT t. FROM TABLE1 as t', { line: 0, column: 9 }, SIMPLE_SCHEMA)
+    expect(result.candidates.length).toEqual(2)
+    expect(result.candidates[0].label).toEqual('COLUMN1')
+    expect(result.candidates[1].label).toEqual('COLUMN2')
+  })
+
+  test("complete ColumnName:cursor on first char:using alias", () => {
+    const result = complete('SELECT t.C FROM TABLE1 as t', { line: 0, column: 10 }, SIMPLE_SCHEMA)
+    expect(result.candidates.length).toEqual(2)
+    expect(result.candidates[0].label).toEqual('COLUMN1')
+    expect(result.candidates[1].label).toEqual('COLUMN2')
+  })
+
+  // TODO: should support this
+  test("complete ColumnName:cursor on first char:using back tick", () => {
+    const result = complete('SELECT `t.C FROM TABLE1 as t', { line: 0, column: 10 }, SIMPLE_SCHEMA)
+    expect(result.candidates.length).toEqual(0)
   })
 })
 
@@ -140,23 +265,23 @@ describe('From clause', () => {
     expect(result.candidates.length).toEqual(1)
     expect(result.candidates[0].label).toEqual('TABLE1')
   })
-  
+
   test("from clause: complete TableName:multi lines", () => {
     const result = complete('SELECT TABLE1.COLUMN1\nFROM T', { line: 1, column: 6 }, SIMPLE_SCHEMA)
     expect(result.candidates.length).toEqual(1)
     expect(result.candidates[0].label).toEqual('TABLE1')
   })
-  
+
   test("from clause: INNER JOIN", () => {
     const result = complete('SELECT TABLE1.COLUMN1 FROM TABLE1 I', { line: 0, column: 35 }, SIMPLE_SCHEMA)
     expect(result.candidates.map(v => v.label)).toContain('INNER JOIN')
   })
-  
+
   test("from clause: LEFT JOIN", () => {
     const result = complete('SELECT TABLE1.COLUMN1 FROM TABLE1 L', { line: 0, column: 35 }, SIMPLE_SCHEMA)
     expect(result.candidates.map(v => v.label).includes('LEFT JOIN'))
   });
-  
+
   test("from clause: complete 'ON' keyword on 'INNER JOIN'", () => {
     const result =
       complete(
@@ -168,112 +293,328 @@ describe('From clause', () => {
   })
 })
 
-describe('Where clasuse', () => {
+describe('Where clause', () => {
   test("where clause: complete TableName", () => {
-    const result = complete('SELECT TABLE1.COLUMN1 FROM TABLE WHERE T', { line: 0, column: 40 }, SIMPLE_SCHEMA)
+    const result = complete('SELECT TABLE1.COLUMN1 FROM TABLE1 WHERE T', { line: 0, column: 41 }, SIMPLE_SCHEMA)
     expect(result.candidates.length).toEqual(1)
     expect(result.candidates[0].label).toEqual('TABLE1')
+  })
+  test("where clause: complete table alias", () => {
+    const result = complete('SELECT tab.COLUMN1 FROM TABLE1 as tab WHERE ta', { line: 0, column: 46 }, SIMPLE_SCHEMA)
+    expect(result.candidates.length).toEqual(1)
+    expect(result.candidates[0].label).toEqual('tab')
   })
 })
 
 describe('cursor on dot', () => {
-  test("not complete when a cursor is on dot in string literal", () => {
+  test("not complete when a cursor is on dot in case sensitive colum name", () => {
     const result =
-      complete('SELECT TABLE1.COLUMN1 FROM TABLE1 WHERE TABLE1.COLUMN1 = "hoge.', { line: 0, column: 63 }, SIMPLE_SCHEMA)
+      complete('SELECT TABLE1.COLUMN1 FROM TABLE1 WHERE TABLE1.COLUMN1 = "COL1.', { line: 0, column: 63 }, SIMPLE_SCHEMA)
     expect(result.candidates.length).toEqual(0)
   })
-  
+
+  test("not complete when a cursor is on dot in case sensitive colum name", () => {
+    const result =
+      complete('SELECT "COL1. FROM TABLE1', { line: 0, column: 13 }, SIMPLE_SCHEMA)
+    expect(result.candidates.length).toEqual(0)
+  })
+
+  test("not complete when a cursor is on dot in string literal", () => {
+    const result =
+      complete("SELECT TABLE1.COLUMN1 FROM TABLE1 WHERE TABLE1.COLUMN1 = 'hoge.", { line: 0, column: 63 }, SIMPLE_SCHEMA)
+    expect(result.candidates.length).toEqual(0)
+  })
+
+  test("not complete when a cursor is on dot in string literal", () => {
+    const result =
+      complete("SELECT 'hoge. FROM TABLE1", { line: 0, column: 13 }, SIMPLE_SCHEMA)
+    expect(result.candidates.length).toEqual(0)
+  })
+
+  // TODO should support this
   test("not complete column name when a cursor is on dot in from clause", () => {
     const result = complete('SELECT TABLE1.COLUMN1 FROM TABLE1.', { line: 0, column: 34 }, SIMPLE_SCHEMA)
-    expect(result.candidates.map(v => v.label)).not.toContain('COLUMN1')
-    expect(result.candidates.map(v => v.label)).not.toContain('COLUMN2')
+    expect(result.candidates.length).toEqual(2)
+    expect(result.candidates[0].label).toEqual('COLUMN1')
+    expect(result.candidates[1].label).toEqual('COLUMN2')
+  })
+
+  // TODO should support this
+  test("not complete when a cursor is on dot in back tick column name", () => {
+    const result = complete('SELECT `TABLE1. FROM TABLE1', { line: 0, column: 15 }, SIMPLE_SCHEMA)
+    expect(result.candidates.length).toEqual(0)
+  })
+
+  test("not complete when ", () => {
+    const result = complete('SELECT    FROM TABLE1', { line: 0, column: 8 }, SIMPLE_SCHEMA)
+    expect(result.candidates.length).toEqual(24) // TODO what are they?
   })
 })
 
-const COMPLEX_SCHEMA = {
-functions: [],
-tables:[
-  {
-     database: null,
-     tableName: 'employees',
-     columns: [
-       { columnName: 'job_id', description: '' },
-       { columnName: 'employee_id', description: '' },
-       { columnName: 'manager_id', description: '' },
-       { columnName: 'department_id', description: '' },
-       { columnName: 'first_name', description: '' },
-       { columnName: 'last_name', description: '' },
-       { columnName: 'email', description: '' },
-       { columnName: 'phone_number', description: '' },
-       { columnName: 'hire_date', description: '' },
-       { columnName: 'salary', description: '' },
-       { columnName: 'commision_pct', description: '' },
-     ]
-  },
-  {
-     database: null,
-     tableName: 'jobs',
-     columns: [
-       { columnName: 'job_id', description: '' },
-       { columnName: 'job_title', description: '' },
-       { columnName: 'min_salary', description: '' },
-       { columnName: 'max_salary', description: '' },
-       { columnName: 'created_at', description: '' },
-       { columnName: 'updated_at', description: '' },
-     ]
-  },
-  {
-     database: null,
-     tableName: 'job_history',
-     columns: [
-       { columnName: 'employee_id', description: '' },
-       { columnName: 'start_date', description: '' },
-       { columnName: 'end_date', description: '' },
-       { columnName: 'job_id', description: '' },
-       { columnName: 'department_id', description: '' },
-     ]
-  },
-  {
-     database: null,
-     tableName: 'departments',
-     columns: [
-       { columnName: 'department_id', description: '' },
-       { columnName: 'department_name', description: '' },
-       { columnName: 'manager_id', description: '' },
-       { columnName: 'location_id', description: '' },
-     ]
-  },
-  {
-     database: null,
-     tableName: 'locations',
-     columns: [
-       { columnName: 'location_id', description: '' },
-       { columnName: 'street_address', description: '' },
-       { columnName: 'postal_code', description: '' },
-       { columnName: 'city', description: '' },
-       { columnName: 'state_province', description: '' },
-       { columnName: 'country_id', description: '' },
-     ]
-  },
-  {
-     database: null,
-     tableName: 'countries',
-     columns: [
-       { columnName: 'country_id', description: '' },
-       { columnName: 'country_name', description: '' },
-       { columnName: 'region_id', description: '' },
-     ]
-  },
-  {
-     database: null,
-     tableName: 'regions',
-     columns: [
-       { columnName: 'region_id', description: '' },
-       { columnName: 'region_name', description: '' },
-     ]
-  },
-]
+const SIMPLE_NESTED_SCHEMA = {
+  tables: [
+    {
+      database: null,
+      tableName: 'TABLE1',
+      columns: [
+        { columnName: 'abc', description: '' },
+        { columnName: 'abc.def', description: '' },
+        { columnName: 'abc.def.ghi', description: '' },
+        { columnName: 'x', description: '' },
+        { columnName: 'x.y', description: '' },
+        { columnName: 'x.y.z', description: '' },
+        { columnName: '`with spaces`', description: '' },
+        { columnName: '`with spaces`.`sub space`', description: '' }
+      ]
+    }
+  ],
+  functions: []
 }
+
+describe('Nested ColumnName completion', () => {
+  test("complete ColumnName", () => {
+    const result = complete('SELECT TABLE1.a FROM TABLE1', { line: 0, column: 15 }, SIMPLE_NESTED_SCHEMA)
+    expect(result.candidates.length).toEqual(3)
+    let expected = [
+      expect.objectContaining({ label: 'abc', insertText: '.abc' }),
+      expect.objectContaining({ label: 'abc.def', insertText: '.abc.def' }),
+      expect.objectContaining({ label: 'abc.def.ghi', insertText: '.abc.def.ghi' }),
+    ]
+    expect(result.candidates).toEqual(expect.arrayContaining(expected))
+  })
+
+  test("complete ColumnName of nested field, dot", () => {
+    const result = complete('SELECT TABLE1.abc. FROM TABLE1', { line: 0, column: 18 }, SIMPLE_NESTED_SCHEMA)
+    expect(result.candidates.length).toEqual(2)
+    let expected = [
+      expect.objectContaining({ label: 'def', insertText: '.def' }),
+      expect.objectContaining({ label: 'def.ghi', insertText: '.def.ghi' }),
+    ]
+    expect(result.candidates).toEqual(expect.arrayContaining(expected))
+  })
+
+  test("complete ColumnName of nested field, chars", () => {
+    const result = complete('SELECT TABLE1.abc.d FROM TABLE1', { line: 0, column: 19 }, SIMPLE_NESTED_SCHEMA)
+    expect(result.candidates.length).toEqual(2)
+    let expected = [
+      expect.objectContaining({ label: 'def', insertText: '.def' }),
+      expect.objectContaining({ label: 'def.ghi', insertText: '.def.ghi' }),
+    ]
+    expect(result.candidates).toEqual(expect.arrayContaining(expected))
+  })
+
+  test("complete ColumnName:cursor on first char:using alias", () => {
+    const result = complete('SELECT t.x.y.z, t. FROM TABLE1 as t', { line: 0, column: 18 }, SIMPLE_NESTED_SCHEMA)
+    expect(result.candidates.length).toEqual(8)
+    expect(result.candidates[0].label).toEqual('abc')
+    expect(result.candidates[1].label).toEqual('abc.def')
+    expect(result.candidates[2].label).toEqual('abc.def.ghi')
+    expect(result.candidates[3].label).toEqual('x')
+    expect(result.candidates[4].label).toEqual('x.y')
+    expect(result.candidates[5].label).toEqual('x.y.z')
+    expect(result.candidates[6].label).toEqual('`with spaces`')
+    expect(result.candidates[7].label).toEqual('`with spaces`.`sub space`')
+  })
+
+  test("complete ColumnName:cursor on first char:using alias", () => {
+    const result = complete('SELECT t.abc. FROM TABLE1 as t', { line: 0, column: 13 }, SIMPLE_NESTED_SCHEMA)
+    expect(result.candidates.length).toEqual(2)
+    expect(result.candidates[0].label).toEqual('def')
+    expect(result.candidates[1].label).toEqual('def.ghi')
+    expect(result.candidates[0].insertText).toEqual('.def')
+    expect(result.candidates[1].insertText).toEqual('.def.ghi')
+  })
+
+  test("complete ColumnName:cursor on first char:using alias", () => {
+    const result = complete('SELECT t.abc.de FROM TABLE1 as t', { line: 0, column: 15 }, SIMPLE_NESTED_SCHEMA)
+    expect(result.candidates.length).toEqual(2)
+    expect(result.candidates[0].label).toEqual('def')
+    expect(result.candidates[1].label).toEqual('def.ghi')
+    expect(result.candidates[0].insertText).toEqual('.def')
+    expect(result.candidates[1].insertText).toEqual('.def.ghi')
+  })
+
+  test("complete ColumnName with space:cursor on first char", () => {
+    const result = complete('SELECT t.`with FROM TABLE1 as t', { line: 0, column: 14 }, SIMPLE_NESTED_SCHEMA)
+    expect(result.candidates.length).toEqual(2)
+    expect(result.candidates[0].label).toEqual('`with spaces`')
+    expect(result.candidates[1].label).toEqual('`with spaces`.`sub space`')
+    expect(result.candidates[0].insertText).toEqual('.`with spaces`')
+    expect(result.candidates[1].insertText).toEqual('.`with spaces`.`sub space`')
+  })
+
+  test("getLastToken", () => {
+    expect(getLastToken("SELECT  abc")).toEqual("abc")
+    expect(getLastToken("SELECT  abc.def")).toEqual("abc.def")
+    expect(getLastToken("SELECT  abc[0]")).toEqual("abc")
+    expect(getLastToken("SELECT  abc[0].")).toEqual("abc.")
+    expect(getLastToken("SELECT  abc[0].d")).toEqual("abc.d")
+    expect(getLastToken("SELECT  abc[0].def[0]")).toEqual("abc.def")
+    expect(getLastToken("SELECT  abc[0].def[0].")).toEqual("abc.def.")
+    expect(getLastToken("SELECT  abc[0].def[0].g")).toEqual("abc.def.g")
+
+    expect(getLastToken("SELECT  abc['key']")).toEqual("abc")
+    expect(getLastToken("SELECT  abc['key.name'].")).toEqual("abc.")
+    expect(getLastToken("SELECT  abc['key'].d")).toEqual("abc.d")
+    expect(getLastToken("SELECT  abc['key'].def['key']")).toEqual("abc.def")
+    expect(getLastToken("SELECT  abc['key'].def['key'].")).toEqual("abc.def.")
+    expect(getLastToken("SELECT  abc['key'].def[0].g")).toEqual("abc.def.g")
+  })
+
+  test("with array subscripted", () => {
+    const result = complete('SELECT t.abc[0]. FROM TABLE1 as t', { line: 0, column: 16 }, SIMPLE_NESTED_SCHEMA)
+    expect(result.candidates.length).toEqual(2)
+    expect(result.candidates[0].label).toEqual('def')
+    expect(result.candidates[1].label).toEqual('def.ghi')
+    expect(result.candidates[0].insertText).toEqual('.def')
+    expect(result.candidates[1].insertText).toEqual('.def.ghi')
+  })
+  
+  test("with array subscripted, first char", () => {
+    const result = complete('SELECT t.abc[0].d FROM TABLE1 as t', { line: 0, column: 17 }, SIMPLE_NESTED_SCHEMA)
+    expect(result.candidates.length).toEqual(2)
+    expect(result.candidates[0].label).toEqual('def')
+    expect(result.candidates[1].label).toEqual('def.ghi')
+    expect(result.candidates[0].insertText).toEqual('.def')
+    expect(result.candidates[1].insertText).toEqual('.def.ghi')
+  })
+
+  test("with map subscripted", () => {
+    const result = complete("SELECT t.abc['key']. FROM TABLE1 as t", { line: 0, column: 20 }, SIMPLE_NESTED_SCHEMA)
+    expect(result.candidates.length).toEqual(2)
+    expect(result.candidates[0].label).toEqual("def")
+    expect(result.candidates[1].label).toEqual("def.ghi")
+    expect(result.candidates[0].insertText).toEqual(".def")
+    expect(result.candidates[1].insertText).toEqual(".def.ghi")
+  })
+  
+  test("with map subscripted, first char", () => {
+    const result = complete("SELECT t.abc['key'].d FROM TABLE1 as t", { line: 0, column: 21 }, SIMPLE_NESTED_SCHEMA)
+    expect(result.candidates.length).toEqual(2)
+    expect(result.candidates[0].label).toEqual("def")
+    expect(result.candidates[1].label).toEqual("def.ghi")
+    expect(result.candidates[0].insertText).toEqual(".def")
+    expect(result.candidates[1].insertText).toEqual(".def.ghi")
+  })
+})
+
+
+const COMPLEX_SCHEMA = {
+  tables: [
+    {
+      database: null,
+      tableName: 'employees',
+      columns: [
+        { columnName: 'job_id', description: '' },
+        { columnName: 'employee_id', description: '' },
+        { columnName: 'manager_id', description: '' },
+        { columnName: 'department_id', description: '' },
+        { columnName: 'first_name', description: '' },
+        { columnName: 'last_name', description: '' },
+        { columnName: 'email', description: '' },
+        { columnName: 'phone_number', description: '' },
+        { columnName: 'hire_date', description: '' },
+        { columnName: 'salary', description: '' },
+        { columnName: 'commision_pct', description: '' },
+      ]
+    },
+    {
+      database: null,
+      tableName: 'jobs',
+      columns: [
+        { columnName: 'job_id', description: '' },
+        { columnName: 'job_title', description: '' },
+        { columnName: 'min_salary', description: '' },
+        { columnName: 'max_salary', description: '' },
+        { columnName: 'created_at', description: '' },
+        { columnName: 'updated_at', description: '' },
+      ]
+    },
+    {
+      database: null,
+      tableName: 'job_history',
+      columns: [
+        { columnName: 'employee_id', description: '' },
+        { columnName: 'start_date', description: '' },
+        { columnName: 'end_date', description: '' },
+        { columnName: 'job_id', description: '' },
+        { columnName: 'department_id', description: '' },
+      ]
+    },
+    {
+      database: null,
+      tableName: 'departments',
+      columns: [
+        { columnName: 'department_id', description: '' },
+        { columnName: 'department_name', description: '' },
+        { columnName: 'manager_id', description: '' },
+        { columnName: 'location_id', description: '' },
+      ]
+    },
+    {
+      database: null,
+      tableName: 'locations',
+      columns: [
+        { columnName: 'location_id', description: '' },
+        { columnName: 'street_address', description: '' },
+        { columnName: 'postal_code', description: '' },
+        { columnName: 'city', description: '' },
+        { columnName: 'state_province', description: '' },
+        { columnName: 'country_id', description: '' },
+      ]
+    },
+    {
+      database: null,
+      tableName: 'countries',
+      columns: [
+        { columnName: 'country_id', description: '' },
+        { columnName: 'country_name', description: '' },
+        { columnName: 'region_id', description: '' },
+      ]
+    },
+    {
+      database: null,
+      tableName: 'regions',
+      columns: [
+        { columnName: 'region_id', description: '' },
+        { columnName: 'region_name', description: '' },
+      ]
+    },
+  ],
+  functions: []
+}
+
+
+test("conplete columns from alias that start chars same as other table", () => {
+  const sql = `
+    SELECT jo.
+      FROM employees jo
+        JOIN jobs job
+          ON jo.job_id = job.job_id
+  `
+  const result = complete(sql, { line: 1, column: 14 }, COMPLEX_SCHEMA)
+  expect(result.candidates.length).toEqual(11)
+})
+
+test("conplete columns from alias that start chars same as other table", () => {
+  const sql = `
+    SELECT job.
+      FROM employees jo
+        JOIN jobs job
+          ON jo.job_id = job.job_id
+  `
+  const result = complete(sql, { line: 1, column: 15 }, COMPLEX_SCHEMA)
+  expect(result.candidates.length).toEqual(6)
+})
+
+test("complete column, alias name matches a table from schema, but should not use it", () => {
+  const sql = `
+    SELECT countr.first_na
+      FROM employees countr
+  `
+  const result = complete(sql, { line: 1, column: 26 }, COMPLEX_SCHEMA)
+  expect(result.candidates.length).toEqual(1)
+})
 
 test("conplete columns from duplicated alias", () => {
   const sql = `
@@ -327,25 +668,49 @@ test("conplete columns innside function", () => {
   expect(result.candidates.length).toEqual(11)
 })
 
+test("conplete columns innside function", () => {
+  const sql = `SELECT TO_CHAR(x.departm, 'MM/DD/YYYY') FROM employees x`
+  const result = complete(sql, { line: 0, column: 24 }, COMPLEX_SCHEMA)
+  expect(result.candidates.length).toEqual(1)
+  expect(result.candidates[0].label).toEqual('department_id')
+  expect(result.candidates[0].insertText).toEqual('.department_id')
+})
+
+test("conplete columns innside function", () => {
+  const sql = `SELECT TO_CHAR(empl, 'MM/DD/YYYY') FROM employees x`
+  const result = complete(sql, { line: 0, column: 19 }, COMPLEX_SCHEMA)
+  expect(result.candidates.length).toEqual(1)
+  expect(result.candidates[0].label).toEqual('employees')
+  //expect(result.candidates[0].insertText).toEqual('oyees')
+})
+
+test("conplete columns innside function", () => {
+  const sql = `SELECT TO_CHAR(an_ali, 'MM/DD/YYYY') FROM employees an_alias`
+  const result = complete(sql, { line: 0, column: 21 }, COMPLEX_SCHEMA)
+  expect(result.candidates.length).toEqual(1)
+  expect(result.candidates[0].label).toEqual('an_alias')
+  //expect(result.candidates[0].insertText).toEqual('as')
+})
+
 describe('From clause subquery', () => {
   test("complete column name inside from clause subquery", () => {
     const sql = 'SELECT sub FROM (SELECT e. FROM employees e) sub'
     const result = complete(sql, { line: 0, column: 26 }, COMPLEX_SCHEMA)
     expect(result.candidates.length).toEqual(11)
   })
-  
+
   test("complete column name inside from clause subquery:nested", () => {
     const sql = 'SELECT sub FROM (SELECT e.employee_id FROM (SELECT e2. FROM employees e2) e) sub'
     const result = complete(sql, { line: 0, column: 54 }, COMPLEX_SCHEMA)
     expect(result.candidates.length).toEqual(11)
   })
-  
+
   test("complete column name inside from clause subquery:multiline", () => {
     const sql = 'SELECT sub\n FROM (SELECT e. FROM employees e) sub'
     const result = complete(sql, { line: 1, column: 16 }, COMPLEX_SCHEMA)
     expect(result.candidates.length).toEqual(11)
   })
-  
+
   test("complete column name from subquery", () => {
     const sql = 'SELECT sub. FROM (SELECT e.employee_id sub_id FROM employees e) sub'
     const result = complete(sql, { line: 0, column: 11 }, COMPLEX_SCHEMA)

--- a/packages/server/test/complete.test.ts
+++ b/packages/server/test/complete.test.ts
@@ -216,7 +216,7 @@ describe('TableName completion', () => {
     const result = complete('SELECT  FROM TABLE1', { line: 0, column: 7 }, SIMPLE_SCHEMA)
     expect(result.candidates.length).toEqual(13)
     let expected = [
-      expect.objectContaining({ label: 'Select all columns from TABLE1', insertText: ' \nTABLE1.COLUMN1,\nTABLE1.COLUMN2' }),
+      expect.objectContaining({ label: 'Select all columns from TABLE1', insertText: 'TABLE1.COLUMN1,\nTABLE1.COLUMN2' }),
     ]
     expect(result.candidates).toEqual(expect.arrayContaining(expected))
   })
@@ -572,8 +572,8 @@ describe('Nested ColumnName completion', () => {
     const result = complete('SELECT TABLE1.abc. FROM TABLE1', { line: 0, column: 18 }, SIMPLE_NESTED_SCHEMA)
     expect(result.candidates.length).toEqual(2)
     let expected = [
-      expect.objectContaining({ label: 'def', insertText: '.def' }),
-      expect.objectContaining({ label: 'def.ghi', insertText: '.def.ghi' }),
+      expect.objectContaining({ label: 'def' }),
+      expect.objectContaining({ label: 'def.ghi' }),
     ]
     expect(result.candidates).toEqual(expect.arrayContaining(expected))
   })
@@ -645,8 +645,6 @@ describe('Nested ColumnName completion', () => {
     expect(result.candidates.length).toEqual(2)
     expect(result.candidates[0].label).toEqual('def')
     expect(result.candidates[1].label).toEqual('def.ghi')
-    expect(result.candidates[0].insertText).toEqual('.def')
-    expect(result.candidates[1].insertText).toEqual('.def.ghi')
   })
 
   test("with array subscripted, first char", () => {
@@ -661,8 +659,6 @@ describe('Nested ColumnName completion', () => {
     expect(result.candidates.length).toEqual(2)
     expect(result.candidates[0].label).toEqual("def")
     expect(result.candidates[1].label).toEqual("def.ghi")
-    expect(result.candidates[0].insertText).toEqual(".def")
-    expect(result.candidates[1].insertText).toEqual(".def.ghi")
   })
 
   test("with map subscripted, first char", () => {
@@ -959,8 +955,6 @@ describe('toCompletionItemForIdentifier', () => {
     )
     const completion = item.toCompletionItem()
     expect(completion.label).toEqual('column1')
-    expect(completion.insertText).toBeUndefined()
-    expect(completion.filterText).toBeUndefined()
   })
   test('complete aliased comlumn name', () => {
     const item = new Identifier(
@@ -971,8 +965,6 @@ describe('toCompletionItemForIdentifier', () => {
     )
     const completion = item.toCompletionItem()
     expect(completion.label).toEqual('column1')
-    expect(completion.insertText).toBeUndefined()
-    expect(completion.filterText).toBeUndefined()
   })
   test('complete aliased nested comlumn last part name', () => {
     const item = new Identifier(
@@ -983,8 +975,6 @@ describe('toCompletionItemForIdentifier', () => {
     )
     const completion = item.toCompletionItem()
     expect(completion.label).toEqual('subcolumn2')
-    expect(completion.insertText).toBeUndefined()
-    expect(completion.filterText).toBeUndefined()
   })
   test('complete aliased nested comlumn first part name', () => {
     const item = new Identifier(
@@ -995,22 +985,8 @@ describe('toCompletionItemForIdentifier', () => {
     )
     const completion = item.toCompletionItem()
     expect(completion.label).toEqual('column1.subcolumn2')
-    expect(completion.insertText).toBeUndefined()
-    expect(completion.filterText).toBeUndefined()
   })
 
-  test('complete aliased nested comlumn (last char is a dot)', () => {
-    const item = new Identifier(
-      'ali.column1.',
-      'ali.column1.subcolumn2',
-      '',
-      COLUMN_ICON
-    )
-    const completion = item.toCompletionItem()
-    expect(completion.label).toEqual('subcolumn2')
-    expect(completion.insertText).toEqual('.subcolumn2')
-    expect(completion.filterText).toEqual('.subcolumn2')
-  })
 
 })
 

--- a/packages/server/test/complete.test.ts
+++ b/packages/server/test/complete.test.ts
@@ -1,4 +1,4 @@
-import {complete, getLastToken, Identifier, COLUMN_ICON} from '../src/complete'
+import { complete, getLastToken, Identifier, COLUMN_ICON } from '../src/complete'
 
 describe('keyword completion', () => {
   test("complete 'SELECT' keyword", () => {
@@ -43,7 +43,7 @@ describe('keyword completion', () => {
     expect(result.candidates.length).toEqual(1)
     expect(result.candidates[0].label).toEqual('WHERE')
   })
-  
+
   test("complete 'WHERE' keyword one space", () => {
     const result = complete('SELECT * FROM FOO AS foo W', { line: 0, column: 26 })
     expect(result.candidates.length).toEqual(1)
@@ -402,7 +402,7 @@ const SIMPLE_NESTED_SCHEMA = {
       database: 'schema2',
       tableName: 'table2',
       columns: [
-        { columnName: 'abc2', description: '' }
+        { columnName: 'abc', description: '' }
       ]
     },
     {
@@ -410,12 +410,25 @@ const SIMPLE_NESTED_SCHEMA = {
       database: 'schema3',
       tableName: 'table3',
       columns: [
-        { columnName: 'abc3', description: '' }
+        { columnName: 'abc', description: '' }
       ]
     },
   ],
   functions: []
 }
+
+describe('JOIN', () => {
+  test("from clause: INNER JOIN", () => {
+    const result = complete(`
+    SELECT 
+      *
+    FROM TABLE1 AS a
+    INN`, { line: 4, column: 7 }, SIMPLE_NESTED_SCHEMA)
+    expect(result.candidates.map(v => v.label)).toContain('INNER JOIN')
+    expect(result.candidates.map(v => v.label)).toContain('INNER JOIN schema2.table2 AS tab ON tab.abc = a.abc')
+    expect(result.candidates.map(v => v.label)).toContain('INNER JOIN catalog3.schema3.table3 AS tab ON tab.abc = a.abc')
+  })
+})
 
 describe('Fully qualified table names', () => {
   test("complete catalog name", () => {
@@ -487,7 +500,7 @@ describe('Fully qualified table names', () => {
     const result = complete('SELECT ali. FROM catalog3.schema3.table3 AS ali', { line: 0, column: 11 }, SIMPLE_NESTED_SCHEMA)
     expect(result.candidates.length).toEqual(1)
     let expected = [
-      expect.objectContaining({ label: 'abc3' }),
+      expect.objectContaining({ label: 'abc' }),
     ]
     expect(result.candidates).toEqual(expect.arrayContaining(expected))
   })
@@ -537,7 +550,7 @@ describe('Fully qualified table names', () => {
     const result = complete('SELECT ali. FROM schema2.table2 AS ali', { line: 0, column: 11 }, SIMPLE_NESTED_SCHEMA)
     expect(result.candidates.length).toEqual(1)
     let expected = [
-      expect.objectContaining({ label: 'abc2' }),
+      expect.objectContaining({ label: 'abc' }),
     ]
     expect(result.candidates).toEqual(expect.arrayContaining(expected))
   })
@@ -608,7 +621,7 @@ describe('Nested ColumnName completion', () => {
     expect(result.candidates[0].label).toEqual('`with spaces`')
     expect(result.candidates[1].label).toEqual('`with spaces`.`sub space`')
   })
-  
+
   test("getLastToken", () => {
     expect(getLastToken("SELECT  abc")).toEqual("abc")
     expect(getLastToken("SELECT  abc.def")).toEqual("abc.def")
@@ -635,7 +648,7 @@ describe('Nested ColumnName completion', () => {
     expect(result.candidates[0].insertText).toEqual('.def')
     expect(result.candidates[1].insertText).toEqual('.def.ghi')
   })
-  
+
   test("with array subscripted, first char", () => {
     const result = complete('SELECT t.abc[0].d FROM TABLE1 as t', { line: 0, column: 17 }, SIMPLE_NESTED_SCHEMA)
     expect(result.candidates.length).toEqual(2)
@@ -651,7 +664,7 @@ describe('Nested ColumnName completion', () => {
     expect(result.candidates[0].insertText).toEqual(".def")
     expect(result.candidates[1].insertText).toEqual(".def.ghi")
   })
-  
+
   test("with map subscripted, first char", () => {
     const result = complete("SELECT t.abc['key'].d FROM TABLE1 as t", { line: 0, column: 21 }, SIMPLE_NESTED_SCHEMA)
     expect(result.candidates.length).toEqual(2)

--- a/packages/server/test/complete.test.ts
+++ b/packages/server/test/complete.test.ts
@@ -146,7 +146,7 @@ const SIMPLE_SCHEMA = {
 describe('on blank space', () => {
   test("complete ", () => {
     const result = complete('', { line: 0, column: 0 }, SIMPLE_SCHEMA)
-    expect(result.candidates.length).toEqual(8)
+    expect(result.candidates.length).toEqual(16)
     let expected = [
       expect.objectContaining({ label: 'SELECT' }),
       expect.objectContaining({ label: 'WHERE' }),
@@ -188,7 +188,7 @@ describe('TableName completion', () => {
     expect(result.candidates.length).toEqual(1)
     expect(result.candidates[0].label).toEqual('TABLE1')
   })
-  test("complete TableName", () => {
+  test("complete alias", () => {
     const result = complete('SELECT ta FROM TABLE1 as tab', { line: 0, column: 9 }, SIMPLE_SCHEMA)
     expect(result.candidates.length).toEqual(1)
     expect(result.candidates[0].label).toEqual('tab')
@@ -851,8 +851,8 @@ describe('From clause subquery', () => {
   })
 
   test("complete column name inside from clause subquery:nested", () => {
-    const sql = 'SELECT sub FROM (SELECT e.employee_id FROM (SELECT e2. FROM employees e2) e) sub'
-    const result = complete(sql, { line: 0, column: 54 }, COMPLEX_SCHEMA)
+    const sql = 'SELECT * FROM (SELECT e.employee_id FROM (SELECT e2. FROM employees e2) e) sub'
+    const result = complete(sql, { line: 0, column: 52 }, COMPLEX_SCHEMA)
     expect(result.candidates.length).toEqual(11)
   })
 

--- a/packages/sql-parser/.vscode/launch.json
+++ b/packages/sql-parser/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Jest Tests",
+            "type": "node",
+            "request": "launch",
+            "runtimeArgs": [
+                "--inspect-brk",
+                "${workspaceRoot}/node_modules/.bin/jest",
+                "--runInBand",
+                "--coverage",
+                "false"
+            ],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen"
+        }
+    ]
+}

--- a/packages/sql-parser/base/fromClauseParser.js
+++ b/packages/sql-parser/base/fromClauseParser.js
@@ -240,13 +240,14 @@ function peg$parse(input, options) {
             }
           */
           },
-      peg$c22 = function(db, t, alias) {
+      peg$c22 = function(cat, db, t, alias) {
             if (t && t.type == 'var') {
               t.as = alias;
               return t;
             } else {
               return  {
                 type: 'table',
+                catalog: cat,
                 db    : db,
                 table : t,
                 as    : alias,
@@ -254,13 +255,29 @@ function peg$parse(input, options) {
               }
             }
           },
-      peg$c23 = function(t, alias) {
+      peg$c23 = function(db, t, alias) {
             if (t && t.type == 'var') {
               t.as = alias;
               return t;
             } else {
               return  {
                 type: 'table',
+                catalog: '',
+                db    : db,
+                table : t,
+                as    : alias,
+                location: location()
+              }
+            }
+          },
+      peg$c24 = function(t, alias) {
+            if (t && t.type == 'var') {
+              t.as = alias;
+              return t;
+            } else {
+              return  {
+                type: 'table',
+                catalog: '',
                 db    : '',
                 table : t,
                 as    : alias,
@@ -268,31 +285,34 @@ function peg$parse(input, options) {
               }
             }
           },
-      peg$c24 = function(s, alias) {
+      peg$c25 = function(s, alias) {
             return  { type: 'subquery', subquery: s, as: alias, location: location() };
           },
-      peg$c25 = function(table, alias) {
+      peg$c26 = function(table, alias) {
             return  { type: 'subquery', subquery: table, as: alias, location: location() };
           },
-      peg$c26 = /^[^)]/,
-      peg$c27 = peg$classExpectation([")"], true, false),
-      peg$c28 = function() {return text()},
-      peg$c29 = function(text, alias) {
+      peg$c27 = /^[^)]/,
+      peg$c28 = peg$classExpectation([")"], true, false),
+      peg$c29 = function() {return text()},
+      peg$c30 = function(text, alias) {
             return  { type: 'incomplete_subquery', text: text.join(''), as: alias, location: location() };
           },
-      peg$c30 = function() { return 'LEFT JOIN'; },
-      peg$c31 = function() { return 'INNER JOIN'; },
-      peg$c32 = function(db) {
+      peg$c31 = function() { return 'LEFT JOIN'; },
+      peg$c32 = function() { return 'INNER JOIN'; },
+      peg$c33 = function(cat) {
+          return cat;
+        },
+      peg$c34 = function(db) {
           return db;
         },
-      peg$c33 = function(table) {
+      peg$c35 = function(table) {
             return table;
           },
-      peg$c34 = function(v) {
+      peg$c36 = function(v) {
             return v.name;
           },
-      peg$c35 = function(e) { return e; },
-      peg$c36 = function(k, e) {
+      peg$c37 = function(e) { return e; },
+      peg$c38 = function(k, e) {
             return {
               type: 'where',
               keyword: k,
@@ -300,8 +320,8 @@ function peg$parse(input, options) {
               location: location()
             }
           },
-      peg$c37 = function(l) { return l; },
-      peg$c38 = function(e, d) {
+      peg$c39 = function(l) { return l; },
+      peg$c40 = function(e, d) {
           var obj = {
             expr : e,
             type : 'ASC'
@@ -311,7 +331,7 @@ function peg$parse(input, options) {
           }
           return obj;
         },
-      peg$c39 = function(i1, tail) {
+      peg$c41 = function(i1, tail) {
             var res = [i1];
             if (tail === null) {
               res.unshift({
@@ -323,7 +343,7 @@ function peg$parse(input, options) {
             }
             return res;
           },
-      peg$c40 = function(db, t, l, w) {
+      peg$c42 = function(db, t, l, w) {
             return {
               type  : 'update',
               db    : db,
@@ -332,7 +352,7 @@ function peg$parse(input, options) {
               where : w
             }
           },
-      peg$c41 = function(t, l, w) {
+      peg$c43 = function(t, l, w) {
             return {
               type  : 'update',
               db    : '',
@@ -341,7 +361,7 @@ function peg$parse(input, options) {
               where : w
             }
           },
-      peg$c42 = function(t, j, l, w) {
+      peg$c44 = function(t, j, l, w) {
             return {
               type  : 'update',
               db    : '',
@@ -351,23 +371,23 @@ function peg$parse(input, options) {
               where : w
             }
           },
-      peg$c43 = "=",
-      peg$c44 = peg$literalExpectation("=", false),
-      peg$c45 = function(c, v) {
+      peg$c45 = "=",
+      peg$c46 = peg$literalExpectation("=", false),
+      peg$c47 = function(c, v) {
             return {
               column: c,
               value : v
             }
           },
-      peg$c46 = function(t, c, v) {
+      peg$c48 = function(t, c, v) {
             return {
               table: t,
               column: c,
               value : v
             }
           },
-      peg$c47 = function() {error('EXPECTED COLUMN NAME')},
-      peg$c48 = function(ri, db, t, c, v) {
+      peg$c49 = function() {error('EXPECTED COLUMN NAME')},
+      peg$c50 = function(ri, db, t, c, v) {
             return {
               type      : ri,
               db        : db,
@@ -376,7 +396,7 @@ function peg$parse(input, options) {
               values    : v
             }
           },
-      peg$c49 = function(ri, db, t, l, u) {
+      peg$c51 = function(ri, db, t, l, u) {
             var v = {
               type  : ri,
               db    : db,
@@ -390,7 +410,7 @@ function peg$parse(input, options) {
 
             return v;
           },
-      peg$c50 = function(ri, t, c, v) {
+      peg$c52 = function(ri, t, c, v) {
             return {
               type      : ri,
               db        : '',
@@ -399,7 +419,7 @@ function peg$parse(input, options) {
               values    : v
             }
           },
-      peg$c51 = function(ri, t, l, u) {
+      peg$c53 = function(ri, t, l, u) {
             var v = {
               type  : ri,
               db    : '',
@@ -413,26 +433,26 @@ function peg$parse(input, options) {
 
             return v;
           },
-      peg$c52 = function(c) {error('EXPECTED COLUMN NAME')},
-      peg$c53 = function(c) {
+      peg$c54 = function(c) {error('EXPECTED COLUMN NAME')},
+      peg$c55 = function(c) {
           return c
         },
-      peg$c54 = function() { return 'insert'; },
-      peg$c55 = function() { return 'replace' },
-      peg$c56 = function(l) {
+      peg$c56 = function() { return 'insert'; },
+      peg$c57 = function() { return 'replace' },
+      peg$c58 = function(l) {
           return {
             type: 'values',
             values: l
           };
         },
-      peg$c57 = function(l) {
+      peg$c59 = function(l) {
           return l;
         },
-      peg$c58 = function(head, tail) {
+      peg$c60 = function(head, tail) {
           var l = createExprList(head, tail);
           return l;
         },
-      peg$c59 = function(head, tail) {
+      peg$c61 = function(head, tail) {
             var el = {
               type : 'expr_list'  
             }
@@ -441,22 +461,22 @@ function peg$parse(input, options) {
             el.value = l;
             return el;
           },
-      peg$c60 = "",
-      peg$c61 = function() {
+      peg$c62 = "",
+      peg$c63 = function() {
             return { 
               type  : 'expr_list',
               value : []
             }
           },
-      peg$c62 = function(head, tail) {
+      peg$c64 = function(head, tail) {
             return createBinaryExprChain(head, tail);
           },
-      peg$c63 = "!",
-      peg$c64 = peg$literalExpectation("!", false),
-      peg$c65 = function(expr) {
+      peg$c65 = "!",
+      peg$c66 = peg$literalExpectation("!", false),
+      peg$c67 = function(expr) {
             return createUnaryExpr('NOT', expr);
           },
-      peg$c66 = function(left, rh) {
+      peg$c68 = function(left, rh) {
             if (rh === null) {
               return left;  
             } else {
@@ -469,31 +489,31 @@ function peg$parse(input, options) {
               return res;
             }
           },
-      peg$c67 = function(l) {
+      peg$c69 = function(l) {
             return {
               type : 'arithmetic',
               tail : l
             }
           },
-      peg$c68 = ">=",
-      peg$c69 = peg$literalExpectation(">=", false),
-      peg$c70 = ">",
-      peg$c71 = peg$literalExpectation(">", false),
-      peg$c72 = "<=",
-      peg$c73 = peg$literalExpectation("<=", false),
-      peg$c74 = "<>",
-      peg$c75 = peg$literalExpectation("<>", false),
-      peg$c76 = "<",
-      peg$c77 = peg$literalExpectation("<", false),
-      peg$c78 = "!=",
-      peg$c79 = peg$literalExpectation("!=", false),
-      peg$c80 = function(op, right) {
+      peg$c70 = ">=",
+      peg$c71 = peg$literalExpectation(">=", false),
+      peg$c72 = ">",
+      peg$c73 = peg$literalExpectation(">", false),
+      peg$c74 = "<=",
+      peg$c75 = peg$literalExpectation("<=", false),
+      peg$c76 = "<>",
+      peg$c77 = peg$literalExpectation("<>", false),
+      peg$c78 = "<",
+      peg$c79 = peg$literalExpectation("<", false),
+      peg$c80 = "!=",
+      peg$c81 = peg$literalExpectation("!=", false),
+      peg$c82 = function(op, right) {
             return {
               op    : op,   
               right : right
             }
           },
-      peg$c81 = function(op, begin, end) {
+      peg$c83 = function(op, begin, end) {
             return {
               op    : op,
               right : {
@@ -502,55 +522,55 @@ function peg$parse(input, options) {
               }
             }
           },
-      peg$c82 = function(nk) { return nk[0] + ' ' + nk[2]; },
-      peg$c83 = function(op, right) {
+      peg$c84 = function(nk) { return nk[0] + ' ' + nk[2]; },
+      peg$c85 = function(op, right) {
             return {
               op    : op,
               right : right
             }
           },
-      peg$c84 = function(op, l) {
+      peg$c86 = function(op, l) {
             return {
               op    : op,
               right : l
             }
           },
-      peg$c85 = function(op, l) {
+      peg$c87 = function(op, l) {
           return {
               op    : op,
               right : l
             }
           },
-      peg$c86 = function(op, e) {
+      peg$c88 = function(op, e) {
             return {
               op    : op,  
               right : e
             }
           },
-      peg$c87 = function(op, l) {
+      peg$c89 = function(op, l) {
             return {
               op    : op,  
               right : l
             }
           },
-      peg$c88 = "+",
-      peg$c89 = peg$literalExpectation("+", false),
-      peg$c90 = "-",
-      peg$c91 = peg$literalExpectation("-", false),
-      peg$c92 = function(head, tail) {
+      peg$c90 = "+",
+      peg$c91 = peg$literalExpectation("+", false),
+      peg$c92 = "-",
+      peg$c93 = peg$literalExpectation("-", false),
+      peg$c94 = function(head, tail) {
             return createBinaryExprChain(head, tail)
           },
-      peg$c93 = "*",
-      peg$c94 = peg$literalExpectation("*", false),
-      peg$c95 = "/",
-      peg$c96 = peg$literalExpectation("/", false),
-      peg$c97 = "%",
-      peg$c98 = peg$literalExpectation("%", false),
-      peg$c99 = function(e) { 
+      peg$c95 = "*",
+      peg$c96 = peg$literalExpectation("*", false),
+      peg$c97 = "/",
+      peg$c98 = peg$literalExpectation("/", false),
+      peg$c99 = "%",
+      peg$c100 = peg$literalExpectation("%", false),
+      peg$c101 = function(e) { 
             e.paren = true; 
             return e; 
           },
-      peg$c100 = function(tbl, col) {
+      peg$c102 = function(tbl, col) {
             return {
               type  : 'column_ref',
               table : tbl, 
@@ -558,7 +578,7 @@ function peg$parse(input, options) {
               location: location()
             }; 
           },
-      peg$c101 = function(col) {
+      peg$c103 = function(col) {
             return {
               type  : 'column_ref',
               table : '', 
@@ -566,35 +586,35 @@ function peg$parse(input, options) {
               location: location()
             };
           },
-      peg$c102 = function(name) { return reservedMap[name.toUpperCase()] === true; },
-      peg$c103 = function(name) {
+      peg$c104 = function(name) { return reservedMap[name.toUpperCase()] === true; },
+      peg$c105 = function(name) {
           return name;
         },
-      peg$c104 = "`",
-      peg$c105 = peg$literalExpectation("`", false),
-      peg$c106 = /^[^`]/,
-      peg$c107 = peg$classExpectation(["`"], true, false),
-      peg$c108 = function(chars) {
+      peg$c106 = "`",
+      peg$c107 = peg$literalExpectation("`", false),
+      peg$c108 = /^[^`]/,
+      peg$c109 = peg$classExpectation(["`"], true, false),
+      peg$c110 = function(chars) {
           return chars.join('');
         },
-      peg$c109 = /^[.]/,
-      peg$c110 = peg$classExpectation(["."], false, false),
-      peg$c111 = function() {
+      peg$c111 = /^[.]/,
+      peg$c112 = peg$classExpectation(["."], false, false),
+      peg$c113 = function() {
           return text();
         },
-      peg$c112 = function() {
+      peg$c114 = function() {
            return text();
         },
-      peg$c113 = function(start, parts) { return start + parts.join(''); },
-      peg$c114 = /^[A-Za-z_]/,
-      peg$c115 = peg$classExpectation([["A", "Z"], ["a", "z"], "_"], false, false),
-      peg$c116 = /^[A-Za-z0-9_]/,
-      peg$c117 = peg$classExpectation([["A", "Z"], ["a", "z"], ["0", "9"], "_"], false, false),
-      peg$c118 = /^[A-Za-z0-9_:[\]']/,
-      peg$c119 = peg$classExpectation([["A", "Z"], ["a", "z"], ["0", "9"], "_", ":", "[", "]", "'"], false, false),
-      peg$c120 = ":",
-      peg$c121 = peg$literalExpectation(":", false),
-      peg$c122 = function(l) { 
+      peg$c115 = function(start, parts) { return start + parts.join(''); },
+      peg$c116 = /^[A-Za-z_]/,
+      peg$c117 = peg$classExpectation([["A", "Z"], ["a", "z"], "_"], false, false),
+      peg$c118 = /^[A-Za-z0-9_]/,
+      peg$c119 = peg$classExpectation([["A", "Z"], ["a", "z"], ["0", "9"], "_"], false, false),
+      peg$c120 = /^[A-Za-z0-9_:[\]']/,
+      peg$c121 = peg$classExpectation([["A", "Z"], ["a", "z"], ["0", "9"], "_", ":", "[", "]", "'"], false, false),
+      peg$c122 = ":",
+      peg$c123 = peg$literalExpectation(":", false),
+      peg$c124 = function(l) { 
           var p = {
             type : 'param',
             value: l[1]
@@ -605,7 +625,7 @@ function peg$parse(input, options) {
           params.push(p);
           return p;
         },
-      peg$c123 = function(name, e) {
+      peg$c125 = function(name, e) {
             return {
               type : 'aggr_func',
               name : name,
@@ -615,7 +635,7 @@ function peg$parse(input, options) {
               location: location()
             }   
           },
-      peg$c124 = function(name, arg) {
+      peg$c126 = function(name, arg) {
             return {
               type : 'aggr_func',
               name : name,
@@ -623,287 +643,287 @@ function peg$parse(input, options) {
               location: location()
             }   
           },
-      peg$c125 = function(e) {
+      peg$c127 = function(e) {
             return {
               expr  : e 
             }
           },
-      peg$c126 = function(d, c) {
+      peg$c128 = function(d, c) {
             return {
               distinct : d, 
               expr   : c
             }
           },
-      peg$c127 = function() {
+      peg$c129 = function() {
             return {
               type  : 'star',
               value : '*'
             }
           },
-      peg$c128 = function(name, l) {
+      peg$c130 = function(name, l) {
             return {
               type : 'function',
               name : name, 
               args : l
             }
           },
-      peg$c129 = function(head, tail) {
+      peg$c131 = function(head, tail) {
             return createList(head, tail); 
           },
-      peg$c130 = function() {
+      peg$c132 = function() {
             return {
               type     : 'null',
               value    : null,
               location : location()
             };  
           },
-      peg$c131 = function() { 
+      peg$c133 = function() { 
             return {
               type     : 'bool',
               value    : true,
               location : location()
             };  
           },
-      peg$c132 = function() { 
+      peg$c134 = function() { 
             return {
               type     : 'bool',
               value    : false,
               location : location()
             };  
           },
-      peg$c133 = "\"",
-      peg$c134 = peg$literalExpectation("\"", false),
-      peg$c135 = "'",
-      peg$c136 = peg$literalExpectation("'", false),
-      peg$c137 = function(ca) {
+      peg$c135 = "\"",
+      peg$c136 = peg$literalExpectation("\"", false),
+      peg$c137 = "'",
+      peg$c138 = peg$literalExpectation("'", false),
+      peg$c139 = function(ca) {
             return {
               type     : 'string',
               value    : ca[1].join(''),
               location : location()
             }
           },
-      peg$c138 = /^[^'\\\0-\x1F\x7F]/,
-      peg$c139 = peg$classExpectation(["'", "\\", ["\0", "\x1F"], "\x7F"], true, false),
-      peg$c140 = /^[^"\\\0-\x1F\x7F]/,
-      peg$c141 = peg$classExpectation(["\"", "\\", ["\0", "\x1F"], "\x7F"], true, false),
-      peg$c142 = "\\'",
-      peg$c143 = peg$literalExpectation("\\'", false),
-      peg$c144 = function() { return "'";  },
-      peg$c145 = "\\\"",
-      peg$c146 = peg$literalExpectation("\\\"", false),
-      peg$c147 = function() { return '"';  },
-      peg$c148 = "\\\\",
-      peg$c149 = peg$literalExpectation("\\\\", false),
-      peg$c150 = function() { return "\\"; },
-      peg$c151 = "\\/",
-      peg$c152 = peg$literalExpectation("\\/", false),
-      peg$c153 = function() { return "/";  },
-      peg$c154 = "\\b",
-      peg$c155 = peg$literalExpectation("\\b", false),
-      peg$c156 = function() { return "\b"; },
-      peg$c157 = "\\f",
-      peg$c158 = peg$literalExpectation("\\f", false),
-      peg$c159 = function() { return "\f"; },
-      peg$c160 = "\\n",
-      peg$c161 = peg$literalExpectation("\\n", false),
-      peg$c162 = function() { return "\n"; },
-      peg$c163 = "\\r",
-      peg$c164 = peg$literalExpectation("\\r", false),
-      peg$c165 = function() { return "\r"; },
-      peg$c166 = "\\t",
-      peg$c167 = peg$literalExpectation("\\t", false),
-      peg$c168 = function() { return "\t"; },
-      peg$c169 = "\\u",
-      peg$c170 = peg$literalExpectation("\\u", false),
-      peg$c171 = function(h1, h2, h3, h4) {
+      peg$c140 = /^[^'\\\0-\x1F\x7F]/,
+      peg$c141 = peg$classExpectation(["'", "\\", ["\0", "\x1F"], "\x7F"], true, false),
+      peg$c142 = /^[^"\\\0-\x1F\x7F]/,
+      peg$c143 = peg$classExpectation(["\"", "\\", ["\0", "\x1F"], "\x7F"], true, false),
+      peg$c144 = "\\'",
+      peg$c145 = peg$literalExpectation("\\'", false),
+      peg$c146 = function() { return "'";  },
+      peg$c147 = "\\\"",
+      peg$c148 = peg$literalExpectation("\\\"", false),
+      peg$c149 = function() { return '"';  },
+      peg$c150 = "\\\\",
+      peg$c151 = peg$literalExpectation("\\\\", false),
+      peg$c152 = function() { return "\\"; },
+      peg$c153 = "\\/",
+      peg$c154 = peg$literalExpectation("\\/", false),
+      peg$c155 = function() { return "/";  },
+      peg$c156 = "\\b",
+      peg$c157 = peg$literalExpectation("\\b", false),
+      peg$c158 = function() { return "\b"; },
+      peg$c159 = "\\f",
+      peg$c160 = peg$literalExpectation("\\f", false),
+      peg$c161 = function() { return "\f"; },
+      peg$c162 = "\\n",
+      peg$c163 = peg$literalExpectation("\\n", false),
+      peg$c164 = function() { return "\n"; },
+      peg$c165 = "\\r",
+      peg$c166 = peg$literalExpectation("\\r", false),
+      peg$c167 = function() { return "\r"; },
+      peg$c168 = "\\t",
+      peg$c169 = peg$literalExpectation("\\t", false),
+      peg$c170 = function() { return "\t"; },
+      peg$c171 = "\\u",
+      peg$c172 = peg$literalExpectation("\\u", false),
+      peg$c173 = function(h1, h2, h3, h4) {
             return String.fromCharCode(parseInt("0x" + h1 + h2 + h3 + h4));
           },
-      peg$c172 = /^[\n\r]/,
-      peg$c173 = peg$classExpectation(["\n", "\r"], false, false),
-      peg$c174 = function(n) {
+      peg$c174 = /^[\n\r]/,
+      peg$c175 = peg$classExpectation(["\n", "\r"], false, false),
+      peg$c176 = function(n) {
             return {
               type    : 'number',
               value   : n,
               location: location() 
             }  
           },
-      peg$c175 = function(int_, frac, exp) { return parseFloat(int_ + frac + exp); },
-      peg$c176 = function(int_, frac) { return parseFloat(int_ + frac);       },
-      peg$c177 = function(int_, exp) { return parseFloat(int_ + exp);        },
-      peg$c178 = function(int_) { return parseFloat(int_);              },
-      peg$c179 = function(digit19, digits) { return digit19 + digits;       },
-      peg$c180 = function(op, digit19, digits) { return "-" + digit19 + digits; },
-      peg$c181 = function(op, digit) { return "-" + digit;            },
-      peg$c182 = ".",
-      peg$c183 = peg$literalExpectation(".", false),
-      peg$c184 = function(digits) { return "." + digits; },
-      peg$c185 = function(e, digits) { return e + digits; },
-      peg$c186 = function(digits) { return digits.join(""); },
-      peg$c187 = /^[0-9]/,
-      peg$c188 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c189 = /^[1-9]/,
-      peg$c190 = peg$classExpectation([["1", "9"]], false, false),
-      peg$c191 = /^[0-9a-fA-F]/,
-      peg$c192 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c193 = /^[eE]/,
-      peg$c194 = peg$classExpectation(["e", "E"], false, false),
-      peg$c195 = /^[+\-]/,
-      peg$c196 = peg$classExpectation(["+", "-"], false, false),
-      peg$c197 = function(e, sign) { return e + (sign || ''); },
-      peg$c198 = "null",
-      peg$c199 = peg$literalExpectation("NULL", true),
-      peg$c200 = "true",
-      peg$c201 = peg$literalExpectation("TRUE", true),
-      peg$c202 = "false",
-      peg$c203 = peg$literalExpectation("FALSE", true),
-      peg$c204 = "show",
-      peg$c205 = peg$literalExpectation("SHOW", true),
-      peg$c206 = "drop",
-      peg$c207 = peg$literalExpectation("DROP", true),
-      peg$c208 = "select",
-      peg$c209 = peg$literalExpectation("SELECT", true),
-      peg$c210 = "update",
-      peg$c211 = peg$literalExpectation("UPDATE", true),
-      peg$c212 = "create",
-      peg$c213 = peg$literalExpectation("CREATE", true),
-      peg$c214 = "delete",
-      peg$c215 = peg$literalExpectation("DELETE", true),
-      peg$c216 = "insert",
-      peg$c217 = peg$literalExpectation("INSERT", true),
-      peg$c218 = "replace",
-      peg$c219 = peg$literalExpectation("REPLACE", true),
-      peg$c220 = "explain",
-      peg$c221 = peg$literalExpectation("EXPLAIN", true),
-      peg$c222 = "into",
-      peg$c223 = peg$literalExpectation("INTO", true),
-      peg$c224 = "from",
-      peg$c225 = peg$literalExpectation("FROM", true),
-      peg$c226 = "set",
-      peg$c227 = peg$literalExpectation("SET", true),
-      peg$c228 = "as",
-      peg$c229 = peg$literalExpectation("AS", true),
-      peg$c230 = "table",
-      peg$c231 = peg$literalExpectation("TABLE", true),
-      peg$c232 = "on",
-      peg$c233 = peg$literalExpectation("ON", true),
-      peg$c234 = "left",
-      peg$c235 = peg$literalExpectation("LEFT", true),
-      peg$c236 = "inner",
-      peg$c237 = peg$literalExpectation("INNER", true),
-      peg$c238 = "join",
-      peg$c239 = peg$literalExpectation("JOIN", true),
-      peg$c240 = "union",
-      peg$c241 = peg$literalExpectation("UNION", true),
-      peg$c242 = "values",
-      peg$c243 = peg$literalExpectation("VALUES", true),
-      peg$c244 = "exists",
-      peg$c245 = peg$literalExpectation("EXISTS", true),
-      peg$c246 = "where",
-      peg$c247 = peg$literalExpectation("WHERE", true),
-      peg$c248 = "group",
-      peg$c249 = peg$literalExpectation("GROUP", true),
-      peg$c250 = "by",
-      peg$c251 = peg$literalExpectation("BY", true),
-      peg$c252 = "order",
-      peg$c253 = peg$literalExpectation("ORDER", true),
-      peg$c254 = "having",
-      peg$c255 = peg$literalExpectation("HAVING", true),
-      peg$c256 = "limit",
-      peg$c257 = peg$literalExpectation("LIMIT", true),
-      peg$c258 = "asc",
-      peg$c259 = peg$literalExpectation("ASC", true),
-      peg$c260 = function() { return 'ASC';      },
-      peg$c261 = "desc",
-      peg$c262 = peg$literalExpectation("DESC", true),
-      peg$c263 = function() { return 'DESC';     },
-      peg$c264 = "all",
-      peg$c265 = peg$literalExpectation("ALL", true),
-      peg$c266 = function() { return 'ALL';      },
-      peg$c267 = "distinct",
-      peg$c268 = peg$literalExpectation("DISTINCT", true),
-      peg$c269 = function() { return 'DISTINCT'; },
-      peg$c270 = "duplicate",
-      peg$c271 = peg$literalExpectation("DUPLICATE", true),
-      peg$c272 = function() { return 'DUPLICATE';},
-      peg$c273 = "between",
-      peg$c274 = peg$literalExpectation("BETWEEN", true),
-      peg$c275 = function() { return 'BETWEEN';  },
-      peg$c276 = "in",
-      peg$c277 = peg$literalExpectation("IN", true),
-      peg$c278 = function() { return 'IN';       },
-      peg$c279 = "is",
-      peg$c280 = peg$literalExpectation("IS", true),
-      peg$c281 = function() { return 'IS';       },
-      peg$c282 = "like",
-      peg$c283 = peg$literalExpectation("LIKE", true),
-      peg$c284 = function() { return 'LIKE';     },
-      peg$c285 = "contains",
-      peg$c286 = peg$literalExpectation("CONTAINS", true),
-      peg$c287 = function() { return 'CONTAINS'; },
-      peg$c288 = "key",
-      peg$c289 = peg$literalExpectation("KEY", true),
-      peg$c290 = function() { return 'KEY';      },
-      peg$c291 = "not",
-      peg$c292 = peg$literalExpectation("NOT", true),
-      peg$c293 = function() { return 'NOT';      },
-      peg$c294 = "and",
-      peg$c295 = peg$literalExpectation("AND", true),
-      peg$c296 = function() { return 'AND';      },
-      peg$c297 = "or",
-      peg$c298 = peg$literalExpectation("OR", true),
-      peg$c299 = function() { return 'OR';       },
-      peg$c300 = "count",
-      peg$c301 = peg$literalExpectation("COUNT", true),
-      peg$c302 = function() { return 'COUNT';    },
-      peg$c303 = "max",
-      peg$c304 = peg$literalExpectation("MAX", true),
-      peg$c305 = function() { return 'MAX';      },
-      peg$c306 = "min",
-      peg$c307 = peg$literalExpectation("MIN", true),
-      peg$c308 = function() { return 'MIN';      },
-      peg$c309 = "sum",
-      peg$c310 = peg$literalExpectation("SUM", true),
-      peg$c311 = function() { return 'SUM';      },
-      peg$c312 = "avg",
-      peg$c313 = peg$literalExpectation("AVG", true),
-      peg$c314 = function() { return 'AVG';      },
-      peg$c315 = ",",
-      peg$c316 = peg$literalExpectation(",", false),
-      peg$c317 = "[",
-      peg$c318 = peg$literalExpectation("[", false),
-      peg$c319 = "]",
-      peg$c320 = peg$literalExpectation("]", false),
-      peg$c321 = /^[ \t\n\r]/,
-      peg$c322 = peg$classExpectation([" ", "\t", "\n", "\r"], false, false),
-      peg$c323 = "--",
-      peg$c324 = peg$literalExpectation("--", false),
-      peg$c325 = "/*",
-      peg$c326 = peg$literalExpectation("/*", false),
-      peg$c327 = "*/",
-      peg$c328 = peg$literalExpectation("*/", false),
-      peg$c329 = ";",
-      peg$c330 = peg$literalExpectation(";", false),
-      peg$c331 = function() { varList = []; return true; },
-      peg$c332 = function(s) {
+      peg$c177 = function(int_, frac, exp) { return parseFloat(int_ + frac + exp); },
+      peg$c178 = function(int_, frac) { return parseFloat(int_ + frac);       },
+      peg$c179 = function(int_, exp) { return parseFloat(int_ + exp);        },
+      peg$c180 = function(int_) { return parseFloat(int_);              },
+      peg$c181 = function(digit19, digits) { return digit19 + digits;       },
+      peg$c182 = function(op, digit19, digits) { return "-" + digit19 + digits; },
+      peg$c183 = function(op, digit) { return "-" + digit;            },
+      peg$c184 = ".",
+      peg$c185 = peg$literalExpectation(".", false),
+      peg$c186 = function(digits) { return "." + digits; },
+      peg$c187 = function(e, digits) { return e + digits; },
+      peg$c188 = function(digits) { return digits.join(""); },
+      peg$c189 = /^[0-9]/,
+      peg$c190 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c191 = /^[1-9]/,
+      peg$c192 = peg$classExpectation([["1", "9"]], false, false),
+      peg$c193 = /^[0-9a-fA-F]/,
+      peg$c194 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c195 = /^[eE]/,
+      peg$c196 = peg$classExpectation(["e", "E"], false, false),
+      peg$c197 = /^[+\-]/,
+      peg$c198 = peg$classExpectation(["+", "-"], false, false),
+      peg$c199 = function(e, sign) { return e + (sign || ''); },
+      peg$c200 = "null",
+      peg$c201 = peg$literalExpectation("NULL", true),
+      peg$c202 = "true",
+      peg$c203 = peg$literalExpectation("TRUE", true),
+      peg$c204 = "false",
+      peg$c205 = peg$literalExpectation("FALSE", true),
+      peg$c206 = "show",
+      peg$c207 = peg$literalExpectation("SHOW", true),
+      peg$c208 = "drop",
+      peg$c209 = peg$literalExpectation("DROP", true),
+      peg$c210 = "select",
+      peg$c211 = peg$literalExpectation("SELECT", true),
+      peg$c212 = "update",
+      peg$c213 = peg$literalExpectation("UPDATE", true),
+      peg$c214 = "create",
+      peg$c215 = peg$literalExpectation("CREATE", true),
+      peg$c216 = "delete",
+      peg$c217 = peg$literalExpectation("DELETE", true),
+      peg$c218 = "insert",
+      peg$c219 = peg$literalExpectation("INSERT", true),
+      peg$c220 = "replace",
+      peg$c221 = peg$literalExpectation("REPLACE", true),
+      peg$c222 = "explain",
+      peg$c223 = peg$literalExpectation("EXPLAIN", true),
+      peg$c224 = "into",
+      peg$c225 = peg$literalExpectation("INTO", true),
+      peg$c226 = "from",
+      peg$c227 = peg$literalExpectation("FROM", true),
+      peg$c228 = "set",
+      peg$c229 = peg$literalExpectation("SET", true),
+      peg$c230 = "as",
+      peg$c231 = peg$literalExpectation("AS", true),
+      peg$c232 = "table",
+      peg$c233 = peg$literalExpectation("TABLE", true),
+      peg$c234 = "on",
+      peg$c235 = peg$literalExpectation("ON", true),
+      peg$c236 = "left",
+      peg$c237 = peg$literalExpectation("LEFT", true),
+      peg$c238 = "inner",
+      peg$c239 = peg$literalExpectation("INNER", true),
+      peg$c240 = "join",
+      peg$c241 = peg$literalExpectation("JOIN", true),
+      peg$c242 = "union",
+      peg$c243 = peg$literalExpectation("UNION", true),
+      peg$c244 = "values",
+      peg$c245 = peg$literalExpectation("VALUES", true),
+      peg$c246 = "exists",
+      peg$c247 = peg$literalExpectation("EXISTS", true),
+      peg$c248 = "where",
+      peg$c249 = peg$literalExpectation("WHERE", true),
+      peg$c250 = "group",
+      peg$c251 = peg$literalExpectation("GROUP", true),
+      peg$c252 = "by",
+      peg$c253 = peg$literalExpectation("BY", true),
+      peg$c254 = "order",
+      peg$c255 = peg$literalExpectation("ORDER", true),
+      peg$c256 = "having",
+      peg$c257 = peg$literalExpectation("HAVING", true),
+      peg$c258 = "limit",
+      peg$c259 = peg$literalExpectation("LIMIT", true),
+      peg$c260 = "asc",
+      peg$c261 = peg$literalExpectation("ASC", true),
+      peg$c262 = function() { return 'ASC';      },
+      peg$c263 = "desc",
+      peg$c264 = peg$literalExpectation("DESC", true),
+      peg$c265 = function() { return 'DESC';     },
+      peg$c266 = "all",
+      peg$c267 = peg$literalExpectation("ALL", true),
+      peg$c268 = function() { return 'ALL';      },
+      peg$c269 = "distinct",
+      peg$c270 = peg$literalExpectation("DISTINCT", true),
+      peg$c271 = function() { return 'DISTINCT'; },
+      peg$c272 = "duplicate",
+      peg$c273 = peg$literalExpectation("DUPLICATE", true),
+      peg$c274 = function() { return 'DUPLICATE';},
+      peg$c275 = "between",
+      peg$c276 = peg$literalExpectation("BETWEEN", true),
+      peg$c277 = function() { return 'BETWEEN';  },
+      peg$c278 = "in",
+      peg$c279 = peg$literalExpectation("IN", true),
+      peg$c280 = function() { return 'IN';       },
+      peg$c281 = "is",
+      peg$c282 = peg$literalExpectation("IS", true),
+      peg$c283 = function() { return 'IS';       },
+      peg$c284 = "like",
+      peg$c285 = peg$literalExpectation("LIKE", true),
+      peg$c286 = function() { return 'LIKE';     },
+      peg$c287 = "contains",
+      peg$c288 = peg$literalExpectation("CONTAINS", true),
+      peg$c289 = function() { return 'CONTAINS'; },
+      peg$c290 = "key",
+      peg$c291 = peg$literalExpectation("KEY", true),
+      peg$c292 = function() { return 'KEY';      },
+      peg$c293 = "not",
+      peg$c294 = peg$literalExpectation("NOT", true),
+      peg$c295 = function() { return 'NOT';      },
+      peg$c296 = "and",
+      peg$c297 = peg$literalExpectation("AND", true),
+      peg$c298 = function() { return 'AND';      },
+      peg$c299 = "or",
+      peg$c300 = peg$literalExpectation("OR", true),
+      peg$c301 = function() { return 'OR';       },
+      peg$c302 = "count",
+      peg$c303 = peg$literalExpectation("COUNT", true),
+      peg$c304 = function() { return 'COUNT';    },
+      peg$c305 = "max",
+      peg$c306 = peg$literalExpectation("MAX", true),
+      peg$c307 = function() { return 'MAX';      },
+      peg$c308 = "min",
+      peg$c309 = peg$literalExpectation("MIN", true),
+      peg$c310 = function() { return 'MIN';      },
+      peg$c311 = "sum",
+      peg$c312 = peg$literalExpectation("SUM", true),
+      peg$c313 = function() { return 'SUM';      },
+      peg$c314 = "avg",
+      peg$c315 = peg$literalExpectation("AVG", true),
+      peg$c316 = function() { return 'AVG';      },
+      peg$c317 = ",",
+      peg$c318 = peg$literalExpectation(",", false),
+      peg$c319 = "[",
+      peg$c320 = peg$literalExpectation("[", false),
+      peg$c321 = "]",
+      peg$c322 = peg$literalExpectation("]", false),
+      peg$c323 = /^[ \t\n\r]/,
+      peg$c324 = peg$classExpectation([" ", "\t", "\n", "\r"], false, false),
+      peg$c325 = "--",
+      peg$c326 = peg$literalExpectation("--", false),
+      peg$c327 = "/*",
+      peg$c328 = peg$literalExpectation("/*", false),
+      peg$c329 = "*/",
+      peg$c330 = peg$literalExpectation("*/", false),
+      peg$c331 = ";",
+      peg$c332 = peg$literalExpectation(";", false),
+      peg$c333 = function() { varList = []; return true; },
+      peg$c334 = function(s) {
             return {
               stmt : s,
               vars: varList
             }
           },
-      peg$c333 = function(va, e) {
+      peg$c335 = function(va, e) {
           return {
             type : 'assign',
             left : va,
             right: e
           }
         },
-      peg$c334 = function(e) {
+      peg$c336 = function(e) {
         return {
           type : 'return',
           expr: e
         }
       },
-      peg$c335 = function(lt, op, rt, expr) {
+      peg$c337 = function(lt, op, rt, expr) {
             return {
               type    : 'join',
               ltable  : lt, 
@@ -912,7 +932,7 @@ function peg$parse(input, options) {
               on      : expr
             }
           },
-      peg$c336 = function(name, l) {
+      peg$c338 = function(name, l) {
             //compatible with original func_call
             return {
               type : 'function',
@@ -923,13 +943,13 @@ function peg$parse(input, options) {
               }
             }
           },
-      peg$c337 = function(l) {
+      peg$c339 = function(l) {
           return {
             type : 'array',
             value : l
           }
         },
-      peg$c338 = function(name, m) {
+      peg$c340 = function(name, m) {
           //push for analysis
           varList.push(name);
           return {
@@ -938,27 +958,27 @@ function peg$parse(input, options) {
             members : m
           }
         },
-      peg$c339 = function(l) {
+      peg$c341 = function(l) {
           var s = [];
           for (var i = 0; i < l.length; i++) {
             s.push(l[i][1]); 
           }
           return s;
         },
-      peg$c340 = "$",
-      peg$c341 = peg$literalExpectation("$", false),
-      peg$c342 = "return",
-      peg$c343 = peg$literalExpectation("return", true),
-      peg$c344 = ":=",
-      peg$c345 = peg$literalExpectation(":=", false),
-      peg$c346 = function(val, t, w) {
+      peg$c342 = "$",
+      peg$c343 = peg$literalExpectation("$", false),
+      peg$c344 = "return",
+      peg$c345 = peg$literalExpectation("return", true),
+      peg$c346 = ":=",
+      peg$c347 = peg$literalExpectation(":=", false),
+      peg$c348 = function(val, t, w) {
             return {
               type    : 'delete',
               table   : t,
               where   : w
             }
           },
-      peg$c347 = function(db, t) {
+      peg$c349 = function(db, t) {
             return  {
               type: 'table',
               db    : db,
@@ -966,7 +986,7 @@ function peg$parse(input, options) {
               location: location()
             }
           },
-      peg$c348 = function(t) {
+      peg$c350 = function(t) {
             return  {
               type: 'table',
               db    : '',
@@ -1973,10 +1993,10 @@ function peg$parse(input, options) {
   }
 
   function peg$parsetable_base() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13;
 
     s0 = peg$currPos;
-    s1 = peg$parsedb_name();
+    s1 = peg$parsecatalog_name();
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
@@ -1984,25 +2004,49 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parsetable_name();
+            s5 = peg$parsedb_name();
             if (s5 !== peg$FAILED) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
-                s7 = peg$parseKW_AS();
-                if (s7 === peg$FAILED) {
-                  s7 = null;
-                }
+                s7 = peg$parseDOT();
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parse__();
                   if (s8 !== peg$FAILED) {
-                    s9 = peg$parseident();
-                    if (s9 === peg$FAILED) {
-                      s9 = null;
-                    }
+                    s9 = peg$parsetable_name();
                     if (s9 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c22(s1, s5, s9);
-                      s0 = s1;
+                      s10 = peg$parse__();
+                      if (s10 !== peg$FAILED) {
+                        s11 = peg$parseKW_AS();
+                        if (s11 === peg$FAILED) {
+                          s11 = null;
+                        }
+                        if (s11 !== peg$FAILED) {
+                          s12 = peg$parse__();
+                          if (s12 !== peg$FAILED) {
+                            s13 = peg$parseident();
+                            if (s13 === peg$FAILED) {
+                              s13 = null;
+                            }
+                            if (s13 !== peg$FAILED) {
+                              peg$savedPos = s0;
+                              s1 = peg$c22(s1, s5, s9, s13);
+                              s0 = s1;
+                            } else {
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
+                            }
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
                     } else {
                       peg$currPos = s0;
                       s0 = peg$FAILED;
@@ -2041,25 +2085,49 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parsetable_name();
+      s1 = peg$parsedb_name();
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
-          s3 = peg$parseKW_AS();
-          if (s3 === peg$FAILED) {
-            s3 = null;
-          }
+          s3 = peg$parseDOT();
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
-              s5 = peg$parseident();
-              if (s5 === peg$FAILED) {
-                s5 = null;
-              }
+              s5 = peg$parsetable_name();
               if (s5 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c23(s1, s5);
-                s0 = s1;
+                s6 = peg$parse__();
+                if (s6 !== peg$FAILED) {
+                  s7 = peg$parseKW_AS();
+                  if (s7 === peg$FAILED) {
+                    s7 = null;
+                  }
+                  if (s7 !== peg$FAILED) {
+                    s8 = peg$parse__();
+                    if (s8 !== peg$FAILED) {
+                      s9 = peg$parseident();
+                      if (s9 === peg$FAILED) {
+                        s9 = null;
+                      }
+                      if (s9 !== peg$FAILED) {
+                        peg$savedPos = s0;
+                        s1 = peg$c23(s1, s5, s9);
+                        s0 = s1;
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -2082,7 +2150,7 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$parseselect_stmt();
+        s1 = peg$parsetable_name();
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
           if (s2 !== peg$FAILED) {
@@ -2123,33 +2191,78 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          s1 = peg$parseLPAREN();
+          s1 = peg$parseselect_stmt();
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
             if (s2 !== peg$FAILED) {
-              s3 = peg$parsetable_base();
+              s3 = peg$parseKW_AS();
+              if (s3 === peg$FAILED) {
+                s3 = null;
+              }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse__();
                 if (s4 !== peg$FAILED) {
-                  s5 = peg$parseRPAREN();
+                  s5 = peg$parseident();
+                  if (s5 === peg$FAILED) {
+                    s5 = null;
+                  }
                   if (s5 !== peg$FAILED) {
-                    s6 = peg$parse__();
-                    if (s6 !== peg$FAILED) {
-                      s7 = peg$parseKW_AS();
-                      if (s7 === peg$FAILED) {
-                        s7 = null;
-                      }
-                      if (s7 !== peg$FAILED) {
-                        s8 = peg$parse__();
-                        if (s8 !== peg$FAILED) {
-                          s9 = peg$parseident();
-                          if (s9 === peg$FAILED) {
-                            s9 = null;
-                          }
-                          if (s9 !== peg$FAILED) {
-                            peg$savedPos = s0;
-                            s1 = peg$c25(s3, s9);
-                            s0 = s1;
+                    peg$savedPos = s0;
+                    s1 = peg$c25(s1, s5);
+                    s0 = s1;
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+          if (s0 === peg$FAILED) {
+            s0 = peg$currPos;
+            s1 = peg$parseLPAREN();
+            if (s1 !== peg$FAILED) {
+              s2 = peg$parse__();
+              if (s2 !== peg$FAILED) {
+                s3 = peg$parsetable_base();
+                if (s3 !== peg$FAILED) {
+                  s4 = peg$parse__();
+                  if (s4 !== peg$FAILED) {
+                    s5 = peg$parseRPAREN();
+                    if (s5 !== peg$FAILED) {
+                      s6 = peg$parse__();
+                      if (s6 !== peg$FAILED) {
+                        s7 = peg$parseKW_AS();
+                        if (s7 === peg$FAILED) {
+                          s7 = null;
+                        }
+                        if (s7 !== peg$FAILED) {
+                          s8 = peg$parse__();
+                          if (s8 !== peg$FAILED) {
+                            s9 = peg$parseident();
+                            if (s9 === peg$FAILED) {
+                              s9 = null;
+                            }
+                            if (s9 !== peg$FAILED) {
+                              peg$savedPos = s0;
+                              s1 = peg$c26(s3, s9);
+                              s0 = s1;
+                            } else {
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
+                            }
                           } else {
                             peg$currPos = s0;
                             s0 = peg$FAILED;
@@ -2182,48 +2295,48 @@ function peg$parse(input, options) {
               peg$currPos = s0;
               s0 = peg$FAILED;
             }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-          if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            s1 = peg$currPos;
-            s2 = peg$parseLPAREN();
-            if (s2 !== peg$FAILED) {
-              s3 = peg$parse__();
-              if (s3 !== peg$FAILED) {
-                s4 = peg$currPos;
-                s5 = [];
-                if (peg$c26.test(input.charAt(peg$currPos))) {
-                  s6 = input.charAt(peg$currPos);
-                  peg$currPos++;
-                } else {
-                  s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c27); }
-                }
-                while (s6 !== peg$FAILED) {
-                  s5.push(s6);
-                  if (peg$c26.test(input.charAt(peg$currPos))) {
+            if (s0 === peg$FAILED) {
+              s0 = peg$currPos;
+              s1 = peg$currPos;
+              s2 = peg$parseLPAREN();
+              if (s2 !== peg$FAILED) {
+                s3 = peg$parse__();
+                if (s3 !== peg$FAILED) {
+                  s4 = peg$currPos;
+                  s5 = [];
+                  if (peg$c27.test(input.charAt(peg$currPos))) {
                     s6 = input.charAt(peg$currPos);
                     peg$currPos++;
                   } else {
                     s6 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c27); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c28); }
                   }
-                }
-                if (s5 !== peg$FAILED) {
-                  peg$savedPos = s4;
-                  s5 = peg$c28();
-                }
-                s4 = s5;
-                if (s4 !== peg$FAILED) {
-                  s5 = peg$parse__();
+                  while (s6 !== peg$FAILED) {
+                    s5.push(s6);
+                    if (peg$c27.test(input.charAt(peg$currPos))) {
+                      s6 = input.charAt(peg$currPos);
+                      peg$currPos++;
+                    } else {
+                      s6 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c28); }
+                    }
+                  }
                   if (s5 !== peg$FAILED) {
-                    s6 = peg$parseRPAREN();
-                    if (s6 !== peg$FAILED) {
-                      s2 = [s2, s3, s4, s5, s6];
-                      s1 = s2;
+                    peg$savedPos = s4;
+                    s5 = peg$c29();
+                  }
+                  s4 = s5;
+                  if (s4 !== peg$FAILED) {
+                    s5 = peg$parse__();
+                    if (s5 !== peg$FAILED) {
+                      s6 = peg$parseRPAREN();
+                      if (s6 !== peg$FAILED) {
+                        s2 = [s2, s3, s4, s5, s6];
+                        s1 = s2;
+                      } else {
+                        peg$currPos = s1;
+                        s1 = peg$FAILED;
+                      }
                     } else {
                       peg$currPos = s1;
                       s1 = peg$FAILED;
@@ -2240,28 +2353,28 @@ function peg$parse(input, options) {
                 peg$currPos = s1;
                 s1 = peg$FAILED;
               }
-            } else {
-              peg$currPos = s1;
-              s1 = peg$FAILED;
-            }
-            if (s1 !== peg$FAILED) {
-              s2 = peg$parse__();
-              if (s2 !== peg$FAILED) {
-                s3 = peg$parseKW_AS();
-                if (s3 === peg$FAILED) {
-                  s3 = null;
-                }
-                if (s3 !== peg$FAILED) {
-                  s4 = peg$parse__();
-                  if (s4 !== peg$FAILED) {
-                    s5 = peg$parseident();
-                    if (s5 === peg$FAILED) {
-                      s5 = null;
-                    }
-                    if (s5 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c29(s1, s5);
-                      s0 = s1;
+              if (s1 !== peg$FAILED) {
+                s2 = peg$parse__();
+                if (s2 !== peg$FAILED) {
+                  s3 = peg$parseKW_AS();
+                  if (s3 === peg$FAILED) {
+                    s3 = null;
+                  }
+                  if (s3 !== peg$FAILED) {
+                    s4 = peg$parse__();
+                    if (s4 !== peg$FAILED) {
+                      s5 = peg$parseident();
+                      if (s5 === peg$FAILED) {
+                        s5 = null;
+                      }
+                      if (s5 !== peg$FAILED) {
+                        peg$savedPos = s0;
+                        s1 = peg$c30(s1, s5);
+                        s0 = s1;
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
                     } else {
                       peg$currPos = s0;
                       s0 = peg$FAILED;
@@ -2278,9 +2391,6 @@ function peg$parse(input, options) {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
               }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
             }
           }
         }
@@ -2301,7 +2411,7 @@ function peg$parse(input, options) {
         s3 = peg$parseKW_JOIN();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c30();
+          s1 = peg$c31();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2339,7 +2449,7 @@ function peg$parse(input, options) {
         s2 = peg$parseKW_JOIN();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c31();
+          s1 = peg$c32();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2354,6 +2464,20 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parsecatalog_name() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    s1 = peg$parseident_name();
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c33(s1);
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
   function peg$parsedb_name() {
     var s0, s1;
 
@@ -2361,7 +2485,7 @@ function peg$parse(input, options) {
     s1 = peg$parseident_name();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c32(s1);
+      s1 = peg$c34(s1);
     }
     s0 = s1;
 
@@ -2375,7 +2499,7 @@ function peg$parse(input, options) {
     s1 = peg$parseident();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c33(s1);
+      s1 = peg$c35(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -2383,7 +2507,7 @@ function peg$parse(input, options) {
       s1 = peg$parsevar_decl();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c34(s1);
+        s1 = peg$c36(s1);
       }
       s0 = s1;
     }
@@ -2402,7 +2526,7 @@ function peg$parse(input, options) {
         s3 = peg$parseor_expr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c35(s3);
+          s1 = peg$c37(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2431,7 +2555,7 @@ function peg$parse(input, options) {
         s3 = peg$parseor_expr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c36(s1, s3);
+          s1 = peg$c38(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2478,7 +2602,7 @@ function peg$parse(input, options) {
             s5 = peg$parsecolumn_ref_list();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c37(s5);
+              s1 = peg$c39(s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2593,7 +2717,7 @@ function peg$parse(input, options) {
       s2 = peg$parseor_expr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c35(s2);
+        s1 = peg$c37(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2622,7 +2746,7 @@ function peg$parse(input, options) {
             s5 = peg$parseorder_by_list();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c37(s5);
+              s1 = peg$c39(s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2745,7 +2869,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c38(s1, s3);
+          s1 = peg$c40(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2812,7 +2936,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c39(s3, s5);
+              s1 = peg$c41(s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2872,7 +2996,7 @@ function peg$parse(input, options) {
                             }
                             if (s13 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c40(s3, s7, s11, s13);
+                              s1 = peg$c42(s3, s7, s11, s13);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -2950,7 +3074,7 @@ function peg$parse(input, options) {
                       }
                       if (s9 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c41(s3, s7, s9);
+                        s1 = peg$c43(s3, s7, s9);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -3021,7 +3145,7 @@ function peg$parse(input, options) {
                             }
                             if (s11 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c42(s3, s5, s9, s11);
+                              s1 = peg$c44(s3, s5, s9, s11);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -3162,11 +3286,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c43;
+          s3 = peg$c45;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          if (peg$silentFails === 0) { peg$fail(peg$c46); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -3174,7 +3298,7 @@ function peg$parse(input, options) {
             s5 = peg$parseadditive_expr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c45(s1, s5);
+              s1 = peg$c47(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3211,11 +3335,11 @@ function peg$parse(input, options) {
                 s6 = peg$parse__();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 61) {
-                    s7 = peg$c43;
+                    s7 = peg$c45;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c44); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c46); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse__();
@@ -3223,7 +3347,7 @@ function peg$parse(input, options) {
                       s9 = peg$parseadditive_expr();
                       if (s9 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c46(s1, s5, s9);
+                        s1 = peg$c48(s1, s5, s9);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -3263,7 +3387,7 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s0 = peg$c47();
+        s0 = peg$c49();
         if (s0) {
           s0 = peg$FAILED;
         } else {
@@ -3306,7 +3430,7 @@ function peg$parse(input, options) {
                             s13 = peg$parsevalue_clause();
                             if (s13 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c48(s1, s5, s9, s11, s13);
+                              s1 = peg$c50(s1, s5, s9, s11, s13);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -3396,7 +3520,7 @@ function peg$parse(input, options) {
                                   }
                                   if (s15 !== peg$FAILED) {
                                     peg$savedPos = s0;
-                                    s1 = peg$c49(s1, s5, s9, s13, s15);
+                                    s1 = peg$c51(s1, s5, s9, s13, s15);
                                     s0 = s1;
                                   } else {
                                     peg$currPos = s0;
@@ -3479,7 +3603,7 @@ function peg$parse(input, options) {
                         s9 = peg$parsevalue_clause();
                         if (s9 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c50(s1, s5, s7, s9);
+                          s1 = peg$c52(s1, s5, s7, s9);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -3545,7 +3669,7 @@ function peg$parse(input, options) {
                               }
                               if (s11 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c51(s1, s5, s9, s11);
+                                s1 = peg$c53(s1, s5, s9, s11);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -3614,7 +3738,7 @@ function peg$parse(input, options) {
             s6 = peg$parseRPAREN();
             if (s6 === peg$FAILED) {
               peg$savedPos = peg$currPos;
-              s6 = peg$c52(s4);
+              s6 = peg$c54(s4);
               if (s6) {
                 s6 = peg$FAILED;
               } else {
@@ -3623,7 +3747,7 @@ function peg$parse(input, options) {
             }
             if (s6 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c53(s4);
+              s4 = peg$c55(s4);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -3663,7 +3787,7 @@ function peg$parse(input, options) {
     s1 = peg$parseKW_INSERT();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c54();
+      s1 = peg$c56();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -3671,7 +3795,7 @@ function peg$parse(input, options) {
       s1 = peg$parseKW_REPLACE();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c55();
+        s1 = peg$c57();
       }
       s0 = s1;
     }
@@ -3690,7 +3814,7 @@ function peg$parse(input, options) {
         s3 = peg$parsevalues();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c56(s3);
+          s1 = peg$c58(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3731,7 +3855,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseset_list();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c57(s9);
+                      s1 = peg$c59(s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -3856,7 +3980,7 @@ function peg$parse(input, options) {
               s6 = peg$parseRPAREN();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c58(s3, s4);
+                s1 = peg$c60(s3, s4);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3952,7 +4076,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c59(s1, s2);
+        s1 = peg$c61(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3972,10 +4096,10 @@ function peg$parse(input, options) {
     s0 = peg$parseexpr_list();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c60;
+      s1 = peg$c62;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c61();
+        s1 = peg$c63();
       }
       s0 = s1;
     }
@@ -4049,7 +4173,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c62(s1, s2);
+        s1 = peg$c64(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4129,7 +4253,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c62(s1, s2);
+        s1 = peg$c64(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4151,21 +4275,21 @@ function peg$parse(input, options) {
     if (s1 === peg$FAILED) {
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 33) {
-        s2 = peg$c63;
+        s2 = peg$c65;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c64); }
+        if (peg$silentFails === 0) { peg$fail(peg$c66); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$currPos;
         peg$silentFails++;
         if (input.charCodeAt(peg$currPos) === 61) {
-          s4 = peg$c43;
+          s4 = peg$c45;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          if (peg$silentFails === 0) { peg$fail(peg$c46); }
         }
         peg$silentFails--;
         if (s4 === peg$FAILED) {
@@ -4192,7 +4316,7 @@ function peg$parse(input, options) {
         s3 = peg$parsenot_expr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c65(s3);
+          s1 = peg$c67(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4227,7 +4351,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c66(s1, s3);
+          s1 = peg$c68(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4336,7 +4460,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c67(s1);
+      s1 = peg$c69(s1);
     }
     s0 = s1;
 
@@ -4346,60 +4470,60 @@ function peg$parse(input, options) {
   function peg$parsearithmetic_comparison_operator() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c68) {
-      s0 = peg$c68;
+    if (input.substr(peg$currPos, 2) === peg$c70) {
+      s0 = peg$c70;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c69); }
+      if (peg$silentFails === 0) { peg$fail(peg$c71); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 62) {
-        s0 = peg$c70;
+        s0 = peg$c72;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c71); }
+        if (peg$silentFails === 0) { peg$fail(peg$c73); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c72) {
-          s0 = peg$c72;
+        if (input.substr(peg$currPos, 2) === peg$c74) {
+          s0 = peg$c74;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c73); }
+          if (peg$silentFails === 0) { peg$fail(peg$c75); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c74) {
-            s0 = peg$c74;
+          if (input.substr(peg$currPos, 2) === peg$c76) {
+            s0 = peg$c76;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c75); }
+            if (peg$silentFails === 0) { peg$fail(peg$c77); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 60) {
-              s0 = peg$c76;
+              s0 = peg$c78;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c77); }
+              if (peg$silentFails === 0) { peg$fail(peg$c79); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 61) {
-                s0 = peg$c43;
+                s0 = peg$c45;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c44); }
+                if (peg$silentFails === 0) { peg$fail(peg$c46); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c78) {
-                  s0 = peg$c78;
+                if (input.substr(peg$currPos, 2) === peg$c80) {
+                  s0 = peg$c80;
                   peg$currPos += 2;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c79); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c81); }
                 }
               }
             }
@@ -4422,7 +4546,7 @@ function peg$parse(input, options) {
         s3 = peg$parseadditive_expr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c80(s1, s3);
+          s1 = peg$c82(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4459,7 +4583,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseadditive_expr();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c81(s1, s3, s7);
+                  s1 = peg$c83(s1, s3, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4520,7 +4644,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c82(s1);
+      s1 = peg$c84(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -4557,7 +4681,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c82(s1);
+      s1 = peg$c84(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -4594,7 +4718,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c82(s1);
+      s1 = peg$c84(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -4615,7 +4739,7 @@ function peg$parse(input, options) {
         s3 = peg$parsecomparison_expr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c83(s1, s3);
+          s1 = peg$c85(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4652,7 +4776,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseRPAREN();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c84(s1, s5);
+                  s1 = peg$c86(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4691,7 +4815,7 @@ function peg$parse(input, options) {
           s3 = peg$parseselect_stmt();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c85(s1, s3);
+            s1 = peg$c87(s1, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4714,7 +4838,7 @@ function peg$parse(input, options) {
             s3 = peg$parsevar_decl();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c86(s1, s3);
+              s1 = peg$c88(s1, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4753,7 +4877,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseRPAREN();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c87(s1, s5);
+                  s1 = peg$c89(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4792,7 +4916,7 @@ function peg$parse(input, options) {
           s3 = peg$parsevar_decl();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c86(s1, s3);
+            s1 = peg$c88(s1, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4877,7 +5001,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c62(s1, s2);
+        s1 = peg$c64(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4895,19 +5019,19 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 43) {
-      s0 = peg$c88;
+      s0 = peg$c90;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c89); }
+      if (peg$silentFails === 0) { peg$fail(peg$c91); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s0 = peg$c90;
+        s0 = peg$c92;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c91); }
+        if (peg$silentFails === 0) { peg$fail(peg$c93); }
       }
     }
 
@@ -4980,7 +5104,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c92(s1, s2);
+        s1 = peg$c94(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4998,27 +5122,27 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 42) {
-      s0 = peg$c93;
+      s0 = peg$c95;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c94); }
+      if (peg$silentFails === 0) { peg$fail(peg$c96); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s0 = peg$c95;
+        s0 = peg$c97;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c96); }
+        if (peg$silentFails === 0) { peg$fail(peg$c98); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 37) {
-          s0 = peg$c97;
+          s0 = peg$c99;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c98); }
+          if (peg$silentFails === 0) { peg$fail(peg$c100); }
         }
       }
     }
@@ -5051,7 +5175,7 @@ function peg$parse(input, options) {
                       s5 = peg$parseRPAREN();
                       if (s5 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c99(s3);
+                        s1 = peg$c101(s3);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -5103,7 +5227,7 @@ function peg$parse(input, options) {
             s5 = peg$parsecolumn();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c100(s1, s5);
+              s1 = peg$c102(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5130,7 +5254,7 @@ function peg$parse(input, options) {
       s1 = peg$parsecolumn();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c101(s1);
+        s1 = peg$c103(s1);
       }
       s0 = s1;
     }
@@ -5225,7 +5349,7 @@ function peg$parse(input, options) {
     s1 = peg$parseident_name();
     if (s1 !== peg$FAILED) {
       peg$savedPos = peg$currPos;
-      s2 = peg$c102(s1);
+      s2 = peg$c104(s1);
       if (s2) {
         s2 = peg$FAILED;
       } else {
@@ -5233,7 +5357,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c103(s1);
+        s1 = peg$c105(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5246,30 +5370,30 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 96) {
-        s1 = peg$c104;
+        s1 = peg$c106;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c105); }
+        if (peg$silentFails === 0) { peg$fail(peg$c107); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
-        if (peg$c106.test(input.charAt(peg$currPos))) {
+        if (peg$c108.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c107); }
+          if (peg$silentFails === 0) { peg$fail(peg$c109); }
         }
         if (s3 !== peg$FAILED) {
           while (s3 !== peg$FAILED) {
             s2.push(s3);
-            if (peg$c106.test(input.charAt(peg$currPos))) {
+            if (peg$c108.test(input.charAt(peg$currPos))) {
               s3 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c107); }
+              if (peg$silentFails === 0) { peg$fail(peg$c109); }
             }
           }
         } else {
@@ -5277,15 +5401,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 96) {
-            s3 = peg$c104;
+            s3 = peg$c106;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c105); }
+            if (peg$silentFails === 0) { peg$fail(peg$c107); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c108(s2);
+            s1 = peg$c110(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5311,7 +5435,7 @@ function peg$parse(input, options) {
     s1 = peg$parsecolumn_name();
     if (s1 !== peg$FAILED) {
       peg$savedPos = peg$currPos;
-      s2 = peg$c102(s1);
+      s2 = peg$c104(s1);
       if (s2) {
         s2 = peg$FAILED;
       } else {
@@ -5319,7 +5443,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c103(s1);
+        s1 = peg$c105(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5335,12 +5459,12 @@ function peg$parse(input, options) {
       if (s1 !== peg$FAILED) {
         s2 = [];
         s3 = peg$currPos;
-        if (peg$c109.test(input.charAt(peg$currPos))) {
+        if (peg$c111.test(input.charAt(peg$currPos))) {
           s4 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c110); }
+          if (peg$silentFails === 0) { peg$fail(peg$c112); }
         }
         if (s4 !== peg$FAILED) {
           s5 = peg$parsebacktik_column();
@@ -5358,12 +5482,12 @@ function peg$parse(input, options) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
           s3 = peg$currPos;
-          if (peg$c109.test(input.charAt(peg$currPos))) {
+          if (peg$c111.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c110); }
+            if (peg$silentFails === 0) { peg$fail(peg$c112); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parsebacktik_column();
@@ -5381,7 +5505,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c111();
+          s1 = peg$c113();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5401,30 +5525,30 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 96) {
-      s1 = peg$c104;
+      s1 = peg$c106;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c105); }
+      if (peg$silentFails === 0) { peg$fail(peg$c107); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c106.test(input.charAt(peg$currPos))) {
+      if (peg$c108.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c107); }
+        if (peg$silentFails === 0) { peg$fail(peg$c109); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c106.test(input.charAt(peg$currPos))) {
+          if (peg$c108.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c107); }
+            if (peg$silentFails === 0) { peg$fail(peg$c109); }
           }
         }
       } else {
@@ -5432,11 +5556,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 96) {
-          s3 = peg$c104;
+          s3 = peg$c106;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c105); }
+          if (peg$silentFails === 0) { peg$fail(peg$c107); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -5472,12 +5596,12 @@ function peg$parse(input, options) {
       if (s2 !== peg$FAILED) {
         s3 = [];
         s4 = peg$currPos;
-        if (peg$c109.test(input.charAt(peg$currPos))) {
+        if (peg$c111.test(input.charAt(peg$currPos))) {
           s5 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c110); }
+          if (peg$silentFails === 0) { peg$fail(peg$c112); }
         }
         if (s5 !== peg$FAILED) {
           s6 = [];
@@ -5504,12 +5628,12 @@ function peg$parse(input, options) {
         while (s4 !== peg$FAILED) {
           s3.push(s4);
           s4 = peg$currPos;
-          if (peg$c109.test(input.charAt(peg$currPos))) {
+          if (peg$c111.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c110); }
+            if (peg$silentFails === 0) { peg$fail(peg$c112); }
           }
           if (s5 !== peg$FAILED) {
             s6 = [];
@@ -5536,7 +5660,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c112();
+          s1 = peg$c114();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5568,7 +5692,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c113(s1, s2);
+        s1 = peg$c115(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5585,20 +5709,6 @@ function peg$parse(input, options) {
   function peg$parseident_start() {
     var s0;
 
-    if (peg$c114.test(input.charAt(peg$currPos))) {
-      s0 = input.charAt(peg$currPos);
-      peg$currPos++;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c115); }
-    }
-
-    return s0;
-  }
-
-  function peg$parseident_part() {
-    var s0;
-
     if (peg$c116.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
@@ -5610,7 +5720,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsecolumn_char() {
+  function peg$parseident_part() {
     var s0;
 
     if (peg$c118.test(input.charAt(peg$currPos))) {
@@ -5624,17 +5734,31 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parsecolumn_char() {
+    var s0;
+
+    if (peg$c120.test(input.charAt(peg$currPos))) {
+      s0 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c121); }
+    }
+
+    return s0;
+  }
+
   function peg$parseparam() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
     s1 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s2 = peg$c120;
+      s2 = peg$c122;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c121); }
+      if (peg$silentFails === 0) { peg$fail(peg$c123); }
     }
     if (s2 !== peg$FAILED) {
       s3 = peg$parseident_name();
@@ -5651,7 +5775,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c122(s1);
+      s1 = peg$c124(s1);
     }
     s0 = s1;
 
@@ -5688,7 +5812,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseRPAREN();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c123(s1, s5);
+                  s1 = peg$c125(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -5758,7 +5882,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseRPAREN();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c124(s1, s5);
+                  s1 = peg$c126(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -5799,7 +5923,7 @@ function peg$parse(input, options) {
     s1 = peg$parsestar_expr();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c125(s1);
+      s1 = peg$c127(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5814,7 +5938,7 @@ function peg$parse(input, options) {
           s3 = peg$parsecolumn_ref();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c126(s1, s3);
+            s1 = peg$c128(s1, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5838,15 +5962,15 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c93;
+      s1 = peg$c95;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c94); }
+      if (peg$silentFails === 0) { peg$fail(peg$c96); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c127();
+      s1 = peg$c129();
     }
     s0 = s1;
 
@@ -5872,7 +5996,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseRPAREN();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c128(s1, s5);
+                  s1 = peg$c130(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -5989,7 +6113,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c129(s1, s2);
+        s1 = peg$c131(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6010,7 +6134,7 @@ function peg$parse(input, options) {
     s1 = peg$parseKW_NULL();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c130();
+      s1 = peg$c132();
     }
     s0 = s1;
 
@@ -6024,7 +6148,7 @@ function peg$parse(input, options) {
     s1 = peg$parseKW_TRUE();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c131();
+      s1 = peg$c133();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6032,7 +6156,7 @@ function peg$parse(input, options) {
       s1 = peg$parseKW_FALSE();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c132();
+        s1 = peg$c134();
       }
       s0 = s1;
     }
@@ -6046,11 +6170,11 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c133;
+      s2 = peg$c135;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c134); }
+      if (peg$silentFails === 0) { peg$fail(peg$c136); }
     }
     if (s2 !== peg$FAILED) {
       s3 = [];
@@ -6061,11 +6185,11 @@ function peg$parse(input, options) {
       }
       if (s3 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s4 = peg$c133;
+          s4 = peg$c135;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c134); }
+          if (peg$silentFails === 0) { peg$fail(peg$c136); }
         }
         if (s4 !== peg$FAILED) {
           s2 = [s2, s3, s4];
@@ -6085,11 +6209,11 @@ function peg$parse(input, options) {
     if (s1 === peg$FAILED) {
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s2 = peg$c135;
+        s2 = peg$c137;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c136); }
+        if (peg$silentFails === 0) { peg$fail(peg$c138); }
       }
       if (s2 !== peg$FAILED) {
         s3 = [];
@@ -6100,11 +6224,11 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s4 = peg$c135;
+            s4 = peg$c137;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c136); }
+            if (peg$silentFails === 0) { peg$fail(peg$c138); }
           }
           if (s4 !== peg$FAILED) {
             s2 = [s2, s3, s4];
@@ -6124,7 +6248,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c137(s1);
+      s1 = peg$c139(s1);
     }
     s0 = s1;
 
@@ -6132,23 +6256,6 @@ function peg$parse(input, options) {
   }
 
   function peg$parsesingle_char() {
-    var s0;
-
-    if (peg$c138.test(input.charAt(peg$currPos))) {
-      s0 = input.charAt(peg$currPos);
-      peg$currPos++;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c139); }
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseescape_char();
-    }
-
-    return s0;
-  }
-
-  function peg$parsedouble_char() {
     var s0;
 
     if (peg$c140.test(input.charAt(peg$currPos))) {
@@ -6165,142 +6272,159 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parsedouble_char() {
+    var s0;
+
+    if (peg$c142.test(input.charAt(peg$currPos))) {
+      s0 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c143); }
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseescape_char();
+    }
+
+    return s0;
+  }
+
   function peg$parseescape_char() {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c142) {
-      s1 = peg$c142;
+    if (input.substr(peg$currPos, 2) === peg$c144) {
+      s1 = peg$c144;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c143); }
+      if (peg$silentFails === 0) { peg$fail(peg$c145); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c144();
+      s1 = peg$c146();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c145) {
-        s1 = peg$c145;
+      if (input.substr(peg$currPos, 2) === peg$c147) {
+        s1 = peg$c147;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c146); }
+        if (peg$silentFails === 0) { peg$fail(peg$c148); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c147();
+        s1 = peg$c149();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c148) {
-          s1 = peg$c148;
+        if (input.substr(peg$currPos, 2) === peg$c150) {
+          s1 = peg$c150;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c149); }
+          if (peg$silentFails === 0) { peg$fail(peg$c151); }
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c150();
+          s1 = peg$c152();
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c151) {
-            s1 = peg$c151;
+          if (input.substr(peg$currPos, 2) === peg$c153) {
+            s1 = peg$c153;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c152); }
+            if (peg$silentFails === 0) { peg$fail(peg$c154); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c153();
+            s1 = peg$c155();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c154) {
-              s1 = peg$c154;
+            if (input.substr(peg$currPos, 2) === peg$c156) {
+              s1 = peg$c156;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c155); }
+              if (peg$silentFails === 0) { peg$fail(peg$c157); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c156();
+              s1 = peg$c158();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
-              if (input.substr(peg$currPos, 2) === peg$c157) {
-                s1 = peg$c157;
+              if (input.substr(peg$currPos, 2) === peg$c159) {
+                s1 = peg$c159;
                 peg$currPos += 2;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c158); }
+                if (peg$silentFails === 0) { peg$fail(peg$c160); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c159();
+                s1 = peg$c161();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
-                if (input.substr(peg$currPos, 2) === peg$c160) {
-                  s1 = peg$c160;
+                if (input.substr(peg$currPos, 2) === peg$c162) {
+                  s1 = peg$c162;
                   peg$currPos += 2;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c161); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c163); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c162();
+                  s1 = peg$c164();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
-                  if (input.substr(peg$currPos, 2) === peg$c163) {
-                    s1 = peg$c163;
+                  if (input.substr(peg$currPos, 2) === peg$c165) {
+                    s1 = peg$c165;
                     peg$currPos += 2;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c164); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c166); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c165();
+                    s1 = peg$c167();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
-                    if (input.substr(peg$currPos, 2) === peg$c166) {
-                      s1 = peg$c166;
+                    if (input.substr(peg$currPos, 2) === peg$c168) {
+                      s1 = peg$c168;
                       peg$currPos += 2;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c167); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c169); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c168();
+                      s1 = peg$c170();
                     }
                     s0 = s1;
                     if (s0 === peg$FAILED) {
                       s0 = peg$currPos;
-                      if (input.substr(peg$currPos, 2) === peg$c169) {
-                        s1 = peg$c169;
+                      if (input.substr(peg$currPos, 2) === peg$c171) {
+                        s1 = peg$c171;
                         peg$currPos += 2;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c170); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c172); }
                       }
                       if (s1 !== peg$FAILED) {
                         s2 = peg$parsehexDigit();
@@ -6312,7 +6436,7 @@ function peg$parse(input, options) {
                               s5 = peg$parsehexDigit();
                               if (s5 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c171(s2, s3, s4, s5);
+                                s1 = peg$c173(s2, s3, s4, s5);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -6350,12 +6474,12 @@ function peg$parse(input, options) {
   function peg$parseline_terminator() {
     var s0;
 
-    if (peg$c172.test(input.charAt(peg$currPos))) {
+    if (peg$c174.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c173); }
+      if (peg$silentFails === 0) { peg$fail(peg$c175); }
     }
 
     return s0;
@@ -6368,7 +6492,7 @@ function peg$parse(input, options) {
     s1 = peg$parsenumber();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c174(s1);
+      s1 = peg$c176(s1);
     }
     s0 = s1;
 
@@ -6388,7 +6512,7 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c175(s1, s2, s3);
+            s1 = peg$c177(s1, s2, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6415,7 +6539,7 @@ function peg$parse(input, options) {
           s3 = peg$parse__();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c176(s1, s2);
+            s1 = peg$c178(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6438,7 +6562,7 @@ function peg$parse(input, options) {
             s3 = peg$parse__();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c177(s1, s2);
+              s1 = peg$c179(s1, s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6459,7 +6583,7 @@ function peg$parse(input, options) {
             s2 = peg$parse__();
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c178(s1);
+              s1 = peg$c180(s1);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6485,7 +6609,7 @@ function peg$parse(input, options) {
       s2 = peg$parsedigits();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c179(s1, s2);
+        s1 = peg$c181(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6500,19 +6624,19 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 45) {
-          s1 = peg$c90;
+          s1 = peg$c92;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c91); }
+          if (peg$silentFails === 0) { peg$fail(peg$c93); }
         }
         if (s1 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 43) {
-            s1 = peg$c88;
+            s1 = peg$c90;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c89); }
+            if (peg$silentFails === 0) { peg$fail(peg$c91); }
           }
         }
         if (s1 !== peg$FAILED) {
@@ -6521,7 +6645,7 @@ function peg$parse(input, options) {
             s3 = peg$parsedigits();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c180(s1, s2, s3);
+              s1 = peg$c182(s1, s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6538,26 +6662,26 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 45) {
-            s1 = peg$c90;
+            s1 = peg$c92;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c91); }
+            if (peg$silentFails === 0) { peg$fail(peg$c93); }
           }
           if (s1 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 43) {
-              s1 = peg$c88;
+              s1 = peg$c90;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c89); }
+              if (peg$silentFails === 0) { peg$fail(peg$c91); }
             }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parsedigit();
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c181(s1, s2);
+              s1 = peg$c183(s1, s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6579,17 +6703,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 46) {
-      s1 = peg$c182;
+      s1 = peg$c184;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c183); }
+      if (peg$silentFails === 0) { peg$fail(peg$c185); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsedigits();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c184(s2);
+        s1 = peg$c186(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6612,7 +6736,7 @@ function peg$parse(input, options) {
       s2 = peg$parsedigits();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c185(s1, s2);
+        s1 = peg$c187(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6642,7 +6766,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c186(s1);
+      s1 = peg$c188(s1);
     }
     s0 = s1;
 
@@ -6650,20 +6774,6 @@ function peg$parse(input, options) {
   }
 
   function peg$parsedigit() {
-    var s0;
-
-    if (peg$c187.test(input.charAt(peg$currPos))) {
-      s0 = input.charAt(peg$currPos);
-      peg$currPos++;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c188); }
-    }
-
-    return s0;
-  }
-
-  function peg$parsedigit19() {
     var s0;
 
     if (peg$c189.test(input.charAt(peg$currPos))) {
@@ -6677,7 +6787,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsehexDigit() {
+  function peg$parsedigit19() {
     var s0;
 
     if (peg$c191.test(input.charAt(peg$currPos))) {
@@ -6691,31 +6801,45 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parsehexDigit() {
+    var s0;
+
+    if (peg$c193.test(input.charAt(peg$currPos))) {
+      s0 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c194); }
+    }
+
+    return s0;
+  }
+
   function peg$parsee() {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c193.test(input.charAt(peg$currPos))) {
+    if (peg$c195.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c194); }
+      if (peg$silentFails === 0) { peg$fail(peg$c196); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c195.test(input.charAt(peg$currPos))) {
+      if (peg$c197.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c196); }
+        if (peg$silentFails === 0) { peg$fail(peg$c198); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c197(s1, s2);
+        s1 = peg$c199(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6730,43 +6854,6 @@ function peg$parse(input, options) {
   }
 
   function peg$parseKW_NULL() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c198) {
-      s1 = input.substr(peg$currPos, 4);
-      peg$currPos += 4;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c199); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseident_start();
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        s1 = [s1, s2];
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseKW_TRUE() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -6803,13 +6890,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_FALSE() {
+  function peg$parseKW_TRUE() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c202) {
-      s1 = input.substr(peg$currPos, 5);
-      peg$currPos += 5;
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c202) {
+      s1 = input.substr(peg$currPos, 4);
+      peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c203); }
@@ -6840,13 +6927,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_SHOW() {
+  function peg$parseKW_FALSE() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c204) {
-      s1 = input.substr(peg$currPos, 4);
-      peg$currPos += 4;
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c204) {
+      s1 = input.substr(peg$currPos, 5);
+      peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c205); }
@@ -6877,7 +6964,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_DROP() {
+  function peg$parseKW_SHOW() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -6914,13 +7001,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_SELECT() {
+  function peg$parseKW_DROP() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c208) {
-      s1 = input.substr(peg$currPos, 6);
-      peg$currPos += 6;
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c208) {
+      s1 = input.substr(peg$currPos, 4);
+      peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c209); }
@@ -6951,7 +7038,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_UPDATE() {
+  function peg$parseKW_SELECT() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -6988,7 +7075,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_CREATE() {
+  function peg$parseKW_UPDATE() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -7025,7 +7112,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_DELETE() {
+  function peg$parseKW_CREATE() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -7062,7 +7149,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_INSERT() {
+  function peg$parseKW_DELETE() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -7099,13 +7186,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_REPLACE() {
+  function peg$parseKW_INSERT() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c218) {
-      s1 = input.substr(peg$currPos, 7);
-      peg$currPos += 7;
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c218) {
+      s1 = input.substr(peg$currPos, 6);
+      peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c219); }
@@ -7136,7 +7223,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_EXPLAIN() {
+  function peg$parseKW_REPLACE() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -7173,13 +7260,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_INTO() {
+  function peg$parseKW_EXPLAIN() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c222) {
-      s1 = input.substr(peg$currPos, 4);
-      peg$currPos += 4;
+    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c222) {
+      s1 = input.substr(peg$currPos, 7);
+      peg$currPos += 7;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c223); }
@@ -7210,7 +7297,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_FROM() {
+  function peg$parseKW_INTO() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -7247,16 +7334,53 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseKW_FROM() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c226) {
+      s1 = input.substr(peg$currPos, 4);
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c227); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseident_start();
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        s1 = [s1, s2];
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
   function peg$parseKW_SET() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c226) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c228) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c227); }
+      if (peg$silentFails === 0) { peg$fail(peg$c229); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7288,12 +7412,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c228) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c230) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c229); }
+      if (peg$silentFails === 0) { peg$fail(peg$c231); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7325,12 +7449,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c230) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c232) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c231); }
+      if (peg$silentFails === 0) { peg$fail(peg$c233); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7362,12 +7486,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c232) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c234) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c233); }
+      if (peg$silentFails === 0) { peg$fail(peg$c235); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7399,12 +7523,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c234) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c236) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c235); }
+      if (peg$silentFails === 0) { peg$fail(peg$c237); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7436,12 +7560,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c236) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c238) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c237); }
+      if (peg$silentFails === 0) { peg$fail(peg$c239); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7473,12 +7597,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c238) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c240) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c239); }
+      if (peg$silentFails === 0) { peg$fail(peg$c241); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7510,46 +7634,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c240) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c242) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c241); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseident_start();
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        s1 = [s1, s2];
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseKW_VALUES() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c242) {
-      s1 = input.substr(peg$currPos, 6);
-      peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c243); }
@@ -7580,7 +7667,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_EXISTS() {
+  function peg$parseKW_VALUES() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -7617,13 +7704,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_WHERE() {
+  function peg$parseKW_EXISTS() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c246) {
-      s1 = input.substr(peg$currPos, 5);
-      peg$currPos += 5;
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c246) {
+      s1 = input.substr(peg$currPos, 6);
+      peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c247); }
@@ -7654,7 +7741,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_GROUP() {
+  function peg$parseKW_WHERE() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -7691,16 +7778,53 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseKW_GROUP() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c250) {
+      s1 = input.substr(peg$currPos, 5);
+      peg$currPos += 5;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c251); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseident_start();
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        s1 = [s1, s2];
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
   function peg$parseKW_BY() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c250) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c252) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c251); }
+      if (peg$silentFails === 0) { peg$fail(peg$c253); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7732,12 +7856,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c252) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c254) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c253); }
+      if (peg$silentFails === 0) { peg$fail(peg$c255); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7769,12 +7893,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c254) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c256) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c255); }
+      if (peg$silentFails === 0) { peg$fail(peg$c257); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7806,12 +7930,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c256) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c258) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c257); }
+      if (peg$silentFails === 0) { peg$fail(peg$c259); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7843,12 +7967,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c258) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c260) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c259); }
+      if (peg$silentFails === 0) { peg$fail(peg$c261); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7863,7 +7987,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c260();
+        s1 = peg$c262();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7881,12 +8005,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c261) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c263) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c262); }
+      if (peg$silentFails === 0) { peg$fail(peg$c264); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7901,7 +8025,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c263();
+        s1 = peg$c265();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7919,12 +8043,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c264) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c266) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c265); }
+      if (peg$silentFails === 0) { peg$fail(peg$c267); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7939,7 +8063,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c266();
+        s1 = peg$c268();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7957,12 +8081,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 8).toLowerCase() === peg$c267) {
+    if (input.substr(peg$currPos, 8).toLowerCase() === peg$c269) {
       s1 = input.substr(peg$currPos, 8);
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c268); }
+      if (peg$silentFails === 0) { peg$fail(peg$c270); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7977,7 +8101,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c269();
+        s1 = peg$c271();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7995,12 +8119,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 9).toLowerCase() === peg$c270) {
+    if (input.substr(peg$currPos, 9).toLowerCase() === peg$c272) {
       s1 = input.substr(peg$currPos, 9);
       peg$currPos += 9;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c271); }
+      if (peg$silentFails === 0) { peg$fail(peg$c273); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8015,7 +8139,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c272();
+        s1 = peg$c274();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8033,12 +8157,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c273) {
+    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c275) {
       s1 = input.substr(peg$currPos, 7);
       peg$currPos += 7;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c274); }
+      if (peg$silentFails === 0) { peg$fail(peg$c276); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8053,7 +8177,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c275();
+        s1 = peg$c277();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8071,12 +8195,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c276) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c278) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c277); }
+      if (peg$silentFails === 0) { peg$fail(peg$c279); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8091,7 +8215,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c278();
+        s1 = peg$c280();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8109,12 +8233,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c279) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c281) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c280); }
+      if (peg$silentFails === 0) { peg$fail(peg$c282); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8129,7 +8253,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c281();
+        s1 = peg$c283();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8147,12 +8271,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c282) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c284) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c283); }
+      if (peg$silentFails === 0) { peg$fail(peg$c285); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8167,7 +8291,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c284();
+        s1 = peg$c286();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8185,12 +8309,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 8).toLowerCase() === peg$c285) {
+    if (input.substr(peg$currPos, 8).toLowerCase() === peg$c287) {
       s1 = input.substr(peg$currPos, 8);
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c286); }
+      if (peg$silentFails === 0) { peg$fail(peg$c288); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8205,7 +8329,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c287();
+        s1 = peg$c289();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8223,12 +8347,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c288) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c290) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c289); }
+      if (peg$silentFails === 0) { peg$fail(peg$c291); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8243,7 +8367,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c290();
+        s1 = peg$c292();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8261,12 +8385,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c291) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c293) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c292); }
+      if (peg$silentFails === 0) { peg$fail(peg$c294); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8281,7 +8405,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c293();
+        s1 = peg$c295();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8299,12 +8423,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c294) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c296) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c295); }
+      if (peg$silentFails === 0) { peg$fail(peg$c297); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8319,7 +8443,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c296();
+        s1 = peg$c298();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8337,12 +8461,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c297) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c299) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c298); }
+      if (peg$silentFails === 0) { peg$fail(peg$c300); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8357,7 +8481,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c299();
+        s1 = peg$c301();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8375,12 +8499,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c300) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c302) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c301); }
+      if (peg$silentFails === 0) { peg$fail(peg$c303); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8395,7 +8519,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c302();
+        s1 = peg$c304();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8413,12 +8537,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c303) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c305) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c304); }
+      if (peg$silentFails === 0) { peg$fail(peg$c306); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8433,7 +8557,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c305();
+        s1 = peg$c307();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8451,12 +8575,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c306) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c308) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c307); }
+      if (peg$silentFails === 0) { peg$fail(peg$c309); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8471,7 +8595,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c308();
+        s1 = peg$c310();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8489,12 +8613,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c309) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c311) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c310); }
+      if (peg$silentFails === 0) { peg$fail(peg$c312); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8509,7 +8633,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c311();
+        s1 = peg$c313();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8527,12 +8651,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c312) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c314) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c313); }
+      if (peg$silentFails === 0) { peg$fail(peg$c315); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8547,7 +8671,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c314();
+        s1 = peg$c316();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8565,11 +8689,11 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 46) {
-      s0 = peg$c182;
+      s0 = peg$c184;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c183); }
+      if (peg$silentFails === 0) { peg$fail(peg$c185); }
     }
 
     return s0;
@@ -8579,11 +8703,11 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 44) {
-      s0 = peg$c315;
+      s0 = peg$c317;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c316); }
+      if (peg$silentFails === 0) { peg$fail(peg$c318); }
     }
 
     return s0;
@@ -8593,11 +8717,11 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 42) {
-      s0 = peg$c93;
+      s0 = peg$c95;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c94); }
+      if (peg$silentFails === 0) { peg$fail(peg$c96); }
     }
 
     return s0;
@@ -8635,11 +8759,11 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 91) {
-      s0 = peg$c317;
+      s0 = peg$c319;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c318); }
+      if (peg$silentFails === 0) { peg$fail(peg$c320); }
     }
 
     return s0;
@@ -8649,11 +8773,11 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 93) {
-      s0 = peg$c319;
+      s0 = peg$c321;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c320); }
+      if (peg$silentFails === 0) { peg$fail(peg$c322); }
     }
 
     return s0;
@@ -8695,12 +8819,12 @@ function peg$parse(input, options) {
   function peg$parsewhitespace() {
     var s0;
 
-    if (peg$c321.test(input.charAt(peg$currPos))) {
+    if (peg$c323.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c322); }
+      if (peg$silentFails === 0) { peg$fail(peg$c324); }
     }
 
     return s0;
@@ -8721,12 +8845,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c323) {
-      s1 = peg$c323;
+    if (input.substr(peg$currPos, 2) === peg$c325) {
+      s1 = peg$c325;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c324); }
+      if (peg$silentFails === 0) { peg$fail(peg$c326); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -8800,24 +8924,24 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c325) {
-      s1 = peg$c325;
+    if (input.substr(peg$currPos, 2) === peg$c327) {
+      s1 = peg$c327;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c326); }
+      if (peg$silentFails === 0) { peg$fail(peg$c328); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c327) {
-        s5 = peg$c327;
+      if (input.substr(peg$currPos, 2) === peg$c329) {
+        s5 = peg$c329;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c328); }
+        if (peg$silentFails === 0) { peg$fail(peg$c330); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -8844,12 +8968,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c327) {
-          s5 = peg$c327;
+        if (input.substr(peg$currPos, 2) === peg$c329) {
+          s5 = peg$c329;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c328); }
+          if (peg$silentFails === 0) { peg$fail(peg$c330); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -8873,12 +8997,12 @@ function peg$parse(input, options) {
         }
       }
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c327) {
-          s3 = peg$c327;
+        if (input.substr(peg$currPos, 2) === peg$c329) {
+          s3 = peg$c329;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c328); }
+          if (peg$silentFails === 0) { peg$fail(peg$c330); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -8905,22 +9029,22 @@ function peg$parse(input, options) {
     s0 = peg$parseEOF();
     if (s0 === peg$FAILED) {
       s0 = [];
-      if (peg$c172.test(input.charAt(peg$currPos))) {
+      if (peg$c174.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c173); }
+        if (peg$silentFails === 0) { peg$fail(peg$c175); }
       }
       if (s1 !== peg$FAILED) {
         while (s1 !== peg$FAILED) {
           s0.push(s1);
-          if (peg$c172.test(input.charAt(peg$currPos))) {
+          if (peg$c174.test(input.charAt(peg$currPos))) {
             s1 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c173); }
+            if (peg$silentFails === 0) { peg$fail(peg$c175); }
           }
         }
       } else {
@@ -8958,11 +9082,11 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 59) {
-      s0 = peg$c329;
+      s0 = peg$c331;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c330); }
+      if (peg$silentFails === 0) { peg$fail(peg$c332); }
     }
 
     return s0;
@@ -8986,7 +9110,7 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     peg$savedPos = peg$currPos;
-    s1 = peg$c331();
+    s1 = peg$c333();
     if (s1) {
       s1 = void 0;
     } else {
@@ -9001,7 +9125,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c332(s3);
+          s1 = peg$c334(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9034,7 +9158,7 @@ function peg$parse(input, options) {
             s5 = peg$parseproc_expr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c333(s1, s5);
+              s1 = peg$c335(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9071,7 +9195,7 @@ function peg$parse(input, options) {
         s3 = peg$parseproc_expr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c334(s3);
+          s1 = peg$c336(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9172,7 +9296,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c62(s1, s2);
+        s1 = peg$c64(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9252,7 +9376,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c62(s1, s2);
+        s1 = peg$c64(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9285,7 +9409,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseon_clause();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c335(s1, s3, s5, s7);
+                  s1 = peg$c337(s1, s3, s5, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9342,7 +9466,7 @@ function peg$parse(input, options) {
                     s5 = peg$parseRPAREN();
                     if (s5 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c99(s3);
+                      s1 = peg$c101(s3);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -9391,7 +9515,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseRPAREN();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c336(s1, s5);
+                  s1 = peg$c338(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9520,7 +9644,7 @@ function peg$parse(input, options) {
             s5 = peg$parseRBRAKE();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c337(s3);
+              s1 = peg$c339(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9557,7 +9681,7 @@ function peg$parse(input, options) {
         s3 = peg$parsemem_chain();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c338(s2, s3);
+          s1 = peg$c340(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9582,11 +9706,11 @@ function peg$parse(input, options) {
     s1 = [];
     s2 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 46) {
-      s3 = peg$c182;
+      s3 = peg$c184;
       peg$currPos++;
     } else {
       s3 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c183); }
+      if (peg$silentFails === 0) { peg$fail(peg$c185); }
     }
     if (s3 !== peg$FAILED) {
       s4 = peg$parseident_name();
@@ -9605,11 +9729,11 @@ function peg$parse(input, options) {
       s1.push(s2);
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s3 = peg$c182;
+        s3 = peg$c184;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c183); }
+        if (peg$silentFails === 0) { peg$fail(peg$c185); }
       }
       if (s3 !== peg$FAILED) {
         s4 = peg$parseident_name();
@@ -9627,7 +9751,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c339(s1);
+      s1 = peg$c341(s1);
     }
     s0 = s1;
 
@@ -9638,22 +9762,8 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 36) {
-      s0 = peg$c340;
+      s0 = peg$c342;
       peg$currPos++;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c341); }
-    }
-
-    return s0;
-  }
-
-  function peg$parseKW_RETURN() {
-    var s0;
-
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c342) {
-      s0 = input.substr(peg$currPos, 6);
-      peg$currPos += 6;
     } else {
       s0 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c343); }
@@ -9662,15 +9772,29 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_ASSIGN() {
+  function peg$parseKW_RETURN() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c344) {
-      s0 = peg$c344;
-      peg$currPos += 2;
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c344) {
+      s0 = input.substr(peg$currPos, 6);
+      peg$currPos += 6;
     } else {
       s0 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c345); }
+    }
+
+    return s0;
+  }
+
+  function peg$parseKW_ASSIGN() {
+    var s0;
+
+    if (input.substr(peg$currPos, 2) === peg$c346) {
+      s0 = peg$c346;
+      peg$currPos += 2;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c347); }
     }
 
     return s0;
@@ -9698,7 +9822,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c346(s1, s5, s7);
+                  s1 = peg$c348(s1, s5, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9761,7 +9885,7 @@ function peg$parse(input, options) {
             s5 = peg$parsetable_name();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c347(s1, s5);
+              s1 = peg$c349(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9788,7 +9912,7 @@ function peg$parse(input, options) {
       s1 = peg$parsetable_name();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c348(s1);
+        s1 = peg$c350(s1);
       }
       s0 = s1;
     }

--- a/packages/sql-parser/base/parser.js
+++ b/packages/sql-parser/base/parser.js
@@ -240,13 +240,14 @@ function peg$parse(input, options) {
             }
           */
           },
-      peg$c22 = function(db, t, alias) {
+      peg$c22 = function(cat, db, t, alias) {
             if (t && t.type == 'var') {
               t.as = alias;
               return t;
             } else {
               return  {
                 type: 'table',
+                catalog: cat,
                 db    : db,
                 table : t,
                 as    : alias,
@@ -254,13 +255,29 @@ function peg$parse(input, options) {
               }
             }
           },
-      peg$c23 = function(t, alias) {
+      peg$c23 = function(db, t, alias) {
             if (t && t.type == 'var') {
               t.as = alias;
               return t;
             } else {
               return  {
                 type: 'table',
+                catalog: '',
+                db    : db,
+                table : t,
+                as    : alias,
+                location: location()
+              }
+            }
+          },
+      peg$c24 = function(t, alias) {
+            if (t && t.type == 'var') {
+              t.as = alias;
+              return t;
+            } else {
+              return  {
+                type: 'table',
+                catalog: '',
                 db    : '',
                 table : t,
                 as    : alias,
@@ -268,31 +285,34 @@ function peg$parse(input, options) {
               }
             }
           },
-      peg$c24 = function(s, alias) {
+      peg$c25 = function(s, alias) {
             return  { type: 'subquery', subquery: s, as: alias, location: location() };
           },
-      peg$c25 = function(table, alias) {
+      peg$c26 = function(table, alias) {
             return  { type: 'subquery', subquery: table, as: alias, location: location() };
           },
-      peg$c26 = /^[^)]/,
-      peg$c27 = peg$classExpectation([")"], true, false),
-      peg$c28 = function() {return text()},
-      peg$c29 = function(text, alias) {
+      peg$c27 = /^[^)]/,
+      peg$c28 = peg$classExpectation([")"], true, false),
+      peg$c29 = function() {return text()},
+      peg$c30 = function(text, alias) {
             return  { type: 'incomplete_subquery', text: text.join(''), as: alias, location: location() };
           },
-      peg$c30 = function() { return 'LEFT JOIN'; },
-      peg$c31 = function() { return 'INNER JOIN'; },
-      peg$c32 = function(db) {
+      peg$c31 = function() { return 'LEFT JOIN'; },
+      peg$c32 = function() { return 'INNER JOIN'; },
+      peg$c33 = function(cat) {
+          return cat;
+        },
+      peg$c34 = function(db) {
           return db;
         },
-      peg$c33 = function(table) {
+      peg$c35 = function(table) {
             return table;
           },
-      peg$c34 = function(v) {
+      peg$c36 = function(v) {
             return v.name;
           },
-      peg$c35 = function(e) { return e; },
-      peg$c36 = function(k, e) {
+      peg$c37 = function(e) { return e; },
+      peg$c38 = function(k, e) {
             return {
               type: 'where',
               keyword: k,
@@ -300,8 +320,8 @@ function peg$parse(input, options) {
               location: location()
             }
           },
-      peg$c37 = function(l) { return l; },
-      peg$c38 = function(e, d) {
+      peg$c39 = function(l) { return l; },
+      peg$c40 = function(e, d) {
           var obj = {
             expr : e,
             type : 'ASC'
@@ -311,7 +331,7 @@ function peg$parse(input, options) {
           }
           return obj;
         },
-      peg$c39 = function(i1, tail) {
+      peg$c41 = function(i1, tail) {
             var res = [i1];
             if (tail === null) {
               res.unshift({
@@ -323,7 +343,7 @@ function peg$parse(input, options) {
             }
             return res;
           },
-      peg$c40 = function(db, t, l, w) {
+      peg$c42 = function(db, t, l, w) {
             return {
               type  : 'update',
               db    : db,
@@ -332,7 +352,7 @@ function peg$parse(input, options) {
               where : w
             }
           },
-      peg$c41 = function(t, l, w) {
+      peg$c43 = function(t, l, w) {
             return {
               type  : 'update',
               db    : '',
@@ -341,7 +361,7 @@ function peg$parse(input, options) {
               where : w
             }
           },
-      peg$c42 = function(t, j, l, w) {
+      peg$c44 = function(t, j, l, w) {
             return {
               type  : 'update',
               db    : '',
@@ -351,23 +371,23 @@ function peg$parse(input, options) {
               where : w
             }
           },
-      peg$c43 = "=",
-      peg$c44 = peg$literalExpectation("=", false),
-      peg$c45 = function(c, v) {
+      peg$c45 = "=",
+      peg$c46 = peg$literalExpectation("=", false),
+      peg$c47 = function(c, v) {
             return {
               column: c,
               value : v
             }
           },
-      peg$c46 = function(t, c, v) {
+      peg$c48 = function(t, c, v) {
             return {
               table: t,
               column: c,
               value : v
             }
           },
-      peg$c47 = function() {error('EXPECTED COLUMN NAME')},
-      peg$c48 = function(ri, db, t, c, v) {
+      peg$c49 = function() {error('EXPECTED COLUMN NAME')},
+      peg$c50 = function(ri, db, t, c, v) {
             return {
               type      : ri,
               db        : db,
@@ -376,7 +396,7 @@ function peg$parse(input, options) {
               values    : v
             }
           },
-      peg$c49 = function(ri, db, t, l, u) {
+      peg$c51 = function(ri, db, t, l, u) {
             var v = {
               type  : ri,
               db    : db,
@@ -390,7 +410,7 @@ function peg$parse(input, options) {
 
             return v;
           },
-      peg$c50 = function(ri, t, c, v) {
+      peg$c52 = function(ri, t, c, v) {
             return {
               type      : ri,
               db        : '',
@@ -399,7 +419,7 @@ function peg$parse(input, options) {
               values    : v
             }
           },
-      peg$c51 = function(ri, t, l, u) {
+      peg$c53 = function(ri, t, l, u) {
             var v = {
               type  : ri,
               db    : '',
@@ -413,26 +433,26 @@ function peg$parse(input, options) {
 
             return v;
           },
-      peg$c52 = function(c) {error('EXPECTED COLUMN NAME')},
-      peg$c53 = function(c) {
+      peg$c54 = function(c) {error('EXPECTED COLUMN NAME')},
+      peg$c55 = function(c) {
           return c
         },
-      peg$c54 = function() { return 'insert'; },
-      peg$c55 = function() { return 'replace' },
-      peg$c56 = function(l) {
+      peg$c56 = function() { return 'insert'; },
+      peg$c57 = function() { return 'replace' },
+      peg$c58 = function(l) {
           return {
             type: 'values',
             values: l
           };
         },
-      peg$c57 = function(l) {
+      peg$c59 = function(l) {
           return l;
         },
-      peg$c58 = function(head, tail) {
+      peg$c60 = function(head, tail) {
           var l = createExprList(head, tail);
           return l;
         },
-      peg$c59 = function(head, tail) {
+      peg$c61 = function(head, tail) {
             var el = {
               type : 'expr_list'  
             }
@@ -441,22 +461,22 @@ function peg$parse(input, options) {
             el.value = l;
             return el;
           },
-      peg$c60 = "",
-      peg$c61 = function() {
+      peg$c62 = "",
+      peg$c63 = function() {
             return { 
               type  : 'expr_list',
               value : []
             }
           },
-      peg$c62 = function(head, tail) {
+      peg$c64 = function(head, tail) {
             return createBinaryExprChain(head, tail);
           },
-      peg$c63 = "!",
-      peg$c64 = peg$literalExpectation("!", false),
-      peg$c65 = function(expr) {
+      peg$c65 = "!",
+      peg$c66 = peg$literalExpectation("!", false),
+      peg$c67 = function(expr) {
             return createUnaryExpr('NOT', expr);
           },
-      peg$c66 = function(left, rh) {
+      peg$c68 = function(left, rh) {
             if (rh === null) {
               return left;  
             } else {
@@ -469,31 +489,31 @@ function peg$parse(input, options) {
               return res;
             }
           },
-      peg$c67 = function(l) {
+      peg$c69 = function(l) {
             return {
               type : 'arithmetic',
               tail : l
             }
           },
-      peg$c68 = ">=",
-      peg$c69 = peg$literalExpectation(">=", false),
-      peg$c70 = ">",
-      peg$c71 = peg$literalExpectation(">", false),
-      peg$c72 = "<=",
-      peg$c73 = peg$literalExpectation("<=", false),
-      peg$c74 = "<>",
-      peg$c75 = peg$literalExpectation("<>", false),
-      peg$c76 = "<",
-      peg$c77 = peg$literalExpectation("<", false),
-      peg$c78 = "!=",
-      peg$c79 = peg$literalExpectation("!=", false),
-      peg$c80 = function(op, right) {
+      peg$c70 = ">=",
+      peg$c71 = peg$literalExpectation(">=", false),
+      peg$c72 = ">",
+      peg$c73 = peg$literalExpectation(">", false),
+      peg$c74 = "<=",
+      peg$c75 = peg$literalExpectation("<=", false),
+      peg$c76 = "<>",
+      peg$c77 = peg$literalExpectation("<>", false),
+      peg$c78 = "<",
+      peg$c79 = peg$literalExpectation("<", false),
+      peg$c80 = "!=",
+      peg$c81 = peg$literalExpectation("!=", false),
+      peg$c82 = function(op, right) {
             return {
               op    : op,   
               right : right
             }
           },
-      peg$c81 = function(op, begin, end) {
+      peg$c83 = function(op, begin, end) {
             return {
               op    : op,
               right : {
@@ -502,55 +522,55 @@ function peg$parse(input, options) {
               }
             }
           },
-      peg$c82 = function(nk) { return nk[0] + ' ' + nk[2]; },
-      peg$c83 = function(op, right) {
+      peg$c84 = function(nk) { return nk[0] + ' ' + nk[2]; },
+      peg$c85 = function(op, right) {
             return {
               op    : op,
               right : right
             }
           },
-      peg$c84 = function(op, l) {
+      peg$c86 = function(op, l) {
             return {
               op    : op,
               right : l
             }
           },
-      peg$c85 = function(op, l) {
+      peg$c87 = function(op, l) {
           return {
               op    : op,
               right : l
             }
           },
-      peg$c86 = function(op, e) {
+      peg$c88 = function(op, e) {
             return {
               op    : op,  
               right : e
             }
           },
-      peg$c87 = function(op, l) {
+      peg$c89 = function(op, l) {
             return {
               op    : op,  
               right : l
             }
           },
-      peg$c88 = "+",
-      peg$c89 = peg$literalExpectation("+", false),
-      peg$c90 = "-",
-      peg$c91 = peg$literalExpectation("-", false),
-      peg$c92 = function(head, tail) {
+      peg$c90 = "+",
+      peg$c91 = peg$literalExpectation("+", false),
+      peg$c92 = "-",
+      peg$c93 = peg$literalExpectation("-", false),
+      peg$c94 = function(head, tail) {
             return createBinaryExprChain(head, tail)
           },
-      peg$c93 = "*",
-      peg$c94 = peg$literalExpectation("*", false),
-      peg$c95 = "/",
-      peg$c96 = peg$literalExpectation("/", false),
-      peg$c97 = "%",
-      peg$c98 = peg$literalExpectation("%", false),
-      peg$c99 = function(e) { 
+      peg$c95 = "*",
+      peg$c96 = peg$literalExpectation("*", false),
+      peg$c97 = "/",
+      peg$c98 = peg$literalExpectation("/", false),
+      peg$c99 = "%",
+      peg$c100 = peg$literalExpectation("%", false),
+      peg$c101 = function(e) { 
             e.paren = true; 
             return e; 
           },
-      peg$c100 = function(tbl, col) {
+      peg$c102 = function(tbl, col) {
             return {
               type  : 'column_ref',
               table : tbl, 
@@ -558,7 +578,7 @@ function peg$parse(input, options) {
               location: location()
             }; 
           },
-      peg$c101 = function(col) {
+      peg$c103 = function(col) {
             return {
               type  : 'column_ref',
               table : '', 
@@ -566,35 +586,35 @@ function peg$parse(input, options) {
               location: location()
             };
           },
-      peg$c102 = function(name) { return reservedMap[name.toUpperCase()] === true; },
-      peg$c103 = function(name) {
+      peg$c104 = function(name) { return reservedMap[name.toUpperCase()] === true; },
+      peg$c105 = function(name) {
           return name;
         },
-      peg$c104 = "`",
-      peg$c105 = peg$literalExpectation("`", false),
-      peg$c106 = /^[^`]/,
-      peg$c107 = peg$classExpectation(["`"], true, false),
-      peg$c108 = function(chars) {
+      peg$c106 = "`",
+      peg$c107 = peg$literalExpectation("`", false),
+      peg$c108 = /^[^`]/,
+      peg$c109 = peg$classExpectation(["`"], true, false),
+      peg$c110 = function(chars) {
           return chars.join('');
         },
-      peg$c109 = /^[.]/,
-      peg$c110 = peg$classExpectation(["."], false, false),
-      peg$c111 = function() {
+      peg$c111 = /^[.]/,
+      peg$c112 = peg$classExpectation(["."], false, false),
+      peg$c113 = function() {
           return text();
         },
-      peg$c112 = function() {
+      peg$c114 = function() {
            return text();
         },
-      peg$c113 = function(start, parts) { return start + parts.join(''); },
-      peg$c114 = /^[A-Za-z_]/,
-      peg$c115 = peg$classExpectation([["A", "Z"], ["a", "z"], "_"], false, false),
-      peg$c116 = /^[A-Za-z0-9_]/,
-      peg$c117 = peg$classExpectation([["A", "Z"], ["a", "z"], ["0", "9"], "_"], false, false),
-      peg$c118 = /^[A-Za-z0-9_:[\]']/,
-      peg$c119 = peg$classExpectation([["A", "Z"], ["a", "z"], ["0", "9"], "_", ":", "[", "]", "'"], false, false),
-      peg$c120 = ":",
-      peg$c121 = peg$literalExpectation(":", false),
-      peg$c122 = function(l) { 
+      peg$c115 = function(start, parts) { return start + parts.join(''); },
+      peg$c116 = /^[A-Za-z_]/,
+      peg$c117 = peg$classExpectation([["A", "Z"], ["a", "z"], "_"], false, false),
+      peg$c118 = /^[A-Za-z0-9_]/,
+      peg$c119 = peg$classExpectation([["A", "Z"], ["a", "z"], ["0", "9"], "_"], false, false),
+      peg$c120 = /^[A-Za-z0-9_:[\]']/,
+      peg$c121 = peg$classExpectation([["A", "Z"], ["a", "z"], ["0", "9"], "_", ":", "[", "]", "'"], false, false),
+      peg$c122 = ":",
+      peg$c123 = peg$literalExpectation(":", false),
+      peg$c124 = function(l) { 
           var p = {
             type : 'param',
             value: l[1]
@@ -605,7 +625,7 @@ function peg$parse(input, options) {
           params.push(p);
           return p;
         },
-      peg$c123 = function(name, e) {
+      peg$c125 = function(name, e) {
             return {
               type : 'aggr_func',
               name : name,
@@ -615,7 +635,7 @@ function peg$parse(input, options) {
               location: location()
             }   
           },
-      peg$c124 = function(name, arg) {
+      peg$c126 = function(name, arg) {
             return {
               type : 'aggr_func',
               name : name,
@@ -623,287 +643,287 @@ function peg$parse(input, options) {
               location: location()
             }   
           },
-      peg$c125 = function(e) {
+      peg$c127 = function(e) {
             return {
               expr  : e 
             }
           },
-      peg$c126 = function(d, c) {
+      peg$c128 = function(d, c) {
             return {
               distinct : d, 
               expr   : c
             }
           },
-      peg$c127 = function() {
+      peg$c129 = function() {
             return {
               type  : 'star',
               value : '*'
             }
           },
-      peg$c128 = function(name, l) {
+      peg$c130 = function(name, l) {
             return {
               type : 'function',
               name : name, 
               args : l
             }
           },
-      peg$c129 = function(head, tail) {
+      peg$c131 = function(head, tail) {
             return createList(head, tail); 
           },
-      peg$c130 = function() {
+      peg$c132 = function() {
             return {
               type     : 'null',
               value    : null,
               location : location()
             };  
           },
-      peg$c131 = function() { 
+      peg$c133 = function() { 
             return {
               type     : 'bool',
               value    : true,
               location : location()
             };  
           },
-      peg$c132 = function() { 
+      peg$c134 = function() { 
             return {
               type     : 'bool',
               value    : false,
               location : location()
             };  
           },
-      peg$c133 = "\"",
-      peg$c134 = peg$literalExpectation("\"", false),
-      peg$c135 = "'",
-      peg$c136 = peg$literalExpectation("'", false),
-      peg$c137 = function(ca) {
+      peg$c135 = "\"",
+      peg$c136 = peg$literalExpectation("\"", false),
+      peg$c137 = "'",
+      peg$c138 = peg$literalExpectation("'", false),
+      peg$c139 = function(ca) {
             return {
               type     : 'string',
               value    : ca[1].join(''),
               location : location()
             }
           },
-      peg$c138 = /^[^'\\\0-\x1F\x7F]/,
-      peg$c139 = peg$classExpectation(["'", "\\", ["\0", "\x1F"], "\x7F"], true, false),
-      peg$c140 = /^[^"\\\0-\x1F\x7F]/,
-      peg$c141 = peg$classExpectation(["\"", "\\", ["\0", "\x1F"], "\x7F"], true, false),
-      peg$c142 = "\\'",
-      peg$c143 = peg$literalExpectation("\\'", false),
-      peg$c144 = function() { return "'";  },
-      peg$c145 = "\\\"",
-      peg$c146 = peg$literalExpectation("\\\"", false),
-      peg$c147 = function() { return '"';  },
-      peg$c148 = "\\\\",
-      peg$c149 = peg$literalExpectation("\\\\", false),
-      peg$c150 = function() { return "\\"; },
-      peg$c151 = "\\/",
-      peg$c152 = peg$literalExpectation("\\/", false),
-      peg$c153 = function() { return "/";  },
-      peg$c154 = "\\b",
-      peg$c155 = peg$literalExpectation("\\b", false),
-      peg$c156 = function() { return "\b"; },
-      peg$c157 = "\\f",
-      peg$c158 = peg$literalExpectation("\\f", false),
-      peg$c159 = function() { return "\f"; },
-      peg$c160 = "\\n",
-      peg$c161 = peg$literalExpectation("\\n", false),
-      peg$c162 = function() { return "\n"; },
-      peg$c163 = "\\r",
-      peg$c164 = peg$literalExpectation("\\r", false),
-      peg$c165 = function() { return "\r"; },
-      peg$c166 = "\\t",
-      peg$c167 = peg$literalExpectation("\\t", false),
-      peg$c168 = function() { return "\t"; },
-      peg$c169 = "\\u",
-      peg$c170 = peg$literalExpectation("\\u", false),
-      peg$c171 = function(h1, h2, h3, h4) {
+      peg$c140 = /^[^'\\\0-\x1F\x7F]/,
+      peg$c141 = peg$classExpectation(["'", "\\", ["\0", "\x1F"], "\x7F"], true, false),
+      peg$c142 = /^[^"\\\0-\x1F\x7F]/,
+      peg$c143 = peg$classExpectation(["\"", "\\", ["\0", "\x1F"], "\x7F"], true, false),
+      peg$c144 = "\\'",
+      peg$c145 = peg$literalExpectation("\\'", false),
+      peg$c146 = function() { return "'";  },
+      peg$c147 = "\\\"",
+      peg$c148 = peg$literalExpectation("\\\"", false),
+      peg$c149 = function() { return '"';  },
+      peg$c150 = "\\\\",
+      peg$c151 = peg$literalExpectation("\\\\", false),
+      peg$c152 = function() { return "\\"; },
+      peg$c153 = "\\/",
+      peg$c154 = peg$literalExpectation("\\/", false),
+      peg$c155 = function() { return "/";  },
+      peg$c156 = "\\b",
+      peg$c157 = peg$literalExpectation("\\b", false),
+      peg$c158 = function() { return "\b"; },
+      peg$c159 = "\\f",
+      peg$c160 = peg$literalExpectation("\\f", false),
+      peg$c161 = function() { return "\f"; },
+      peg$c162 = "\\n",
+      peg$c163 = peg$literalExpectation("\\n", false),
+      peg$c164 = function() { return "\n"; },
+      peg$c165 = "\\r",
+      peg$c166 = peg$literalExpectation("\\r", false),
+      peg$c167 = function() { return "\r"; },
+      peg$c168 = "\\t",
+      peg$c169 = peg$literalExpectation("\\t", false),
+      peg$c170 = function() { return "\t"; },
+      peg$c171 = "\\u",
+      peg$c172 = peg$literalExpectation("\\u", false),
+      peg$c173 = function(h1, h2, h3, h4) {
             return String.fromCharCode(parseInt("0x" + h1 + h2 + h3 + h4));
           },
-      peg$c172 = /^[\n\r]/,
-      peg$c173 = peg$classExpectation(["\n", "\r"], false, false),
-      peg$c174 = function(n) {
+      peg$c174 = /^[\n\r]/,
+      peg$c175 = peg$classExpectation(["\n", "\r"], false, false),
+      peg$c176 = function(n) {
             return {
               type    : 'number',
               value   : n,
               location: location() 
             }  
           },
-      peg$c175 = function(int_, frac, exp) { return parseFloat(int_ + frac + exp); },
-      peg$c176 = function(int_, frac) { return parseFloat(int_ + frac);       },
-      peg$c177 = function(int_, exp) { return parseFloat(int_ + exp);        },
-      peg$c178 = function(int_) { return parseFloat(int_);              },
-      peg$c179 = function(digit19, digits) { return digit19 + digits;       },
-      peg$c180 = function(op, digit19, digits) { return "-" + digit19 + digits; },
-      peg$c181 = function(op, digit) { return "-" + digit;            },
-      peg$c182 = ".",
-      peg$c183 = peg$literalExpectation(".", false),
-      peg$c184 = function(digits) { return "." + digits; },
-      peg$c185 = function(e, digits) { return e + digits; },
-      peg$c186 = function(digits) { return digits.join(""); },
-      peg$c187 = /^[0-9]/,
-      peg$c188 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c189 = /^[1-9]/,
-      peg$c190 = peg$classExpectation([["1", "9"]], false, false),
-      peg$c191 = /^[0-9a-fA-F]/,
-      peg$c192 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c193 = /^[eE]/,
-      peg$c194 = peg$classExpectation(["e", "E"], false, false),
-      peg$c195 = /^[+\-]/,
-      peg$c196 = peg$classExpectation(["+", "-"], false, false),
-      peg$c197 = function(e, sign) { return e + (sign || ''); },
-      peg$c198 = "null",
-      peg$c199 = peg$literalExpectation("NULL", true),
-      peg$c200 = "true",
-      peg$c201 = peg$literalExpectation("TRUE", true),
-      peg$c202 = "false",
-      peg$c203 = peg$literalExpectation("FALSE", true),
-      peg$c204 = "show",
-      peg$c205 = peg$literalExpectation("SHOW", true),
-      peg$c206 = "drop",
-      peg$c207 = peg$literalExpectation("DROP", true),
-      peg$c208 = "select",
-      peg$c209 = peg$literalExpectation("SELECT", true),
-      peg$c210 = "update",
-      peg$c211 = peg$literalExpectation("UPDATE", true),
-      peg$c212 = "create",
-      peg$c213 = peg$literalExpectation("CREATE", true),
-      peg$c214 = "delete",
-      peg$c215 = peg$literalExpectation("DELETE", true),
-      peg$c216 = "insert",
-      peg$c217 = peg$literalExpectation("INSERT", true),
-      peg$c218 = "replace",
-      peg$c219 = peg$literalExpectation("REPLACE", true),
-      peg$c220 = "explain",
-      peg$c221 = peg$literalExpectation("EXPLAIN", true),
-      peg$c222 = "into",
-      peg$c223 = peg$literalExpectation("INTO", true),
-      peg$c224 = "from",
-      peg$c225 = peg$literalExpectation("FROM", true),
-      peg$c226 = "set",
-      peg$c227 = peg$literalExpectation("SET", true),
-      peg$c228 = "as",
-      peg$c229 = peg$literalExpectation("AS", true),
-      peg$c230 = "table",
-      peg$c231 = peg$literalExpectation("TABLE", true),
-      peg$c232 = "on",
-      peg$c233 = peg$literalExpectation("ON", true),
-      peg$c234 = "left",
-      peg$c235 = peg$literalExpectation("LEFT", true),
-      peg$c236 = "inner",
-      peg$c237 = peg$literalExpectation("INNER", true),
-      peg$c238 = "join",
-      peg$c239 = peg$literalExpectation("JOIN", true),
-      peg$c240 = "union",
-      peg$c241 = peg$literalExpectation("UNION", true),
-      peg$c242 = "values",
-      peg$c243 = peg$literalExpectation("VALUES", true),
-      peg$c244 = "exists",
-      peg$c245 = peg$literalExpectation("EXISTS", true),
-      peg$c246 = "where",
-      peg$c247 = peg$literalExpectation("WHERE", true),
-      peg$c248 = "group",
-      peg$c249 = peg$literalExpectation("GROUP", true),
-      peg$c250 = "by",
-      peg$c251 = peg$literalExpectation("BY", true),
-      peg$c252 = "order",
-      peg$c253 = peg$literalExpectation("ORDER", true),
-      peg$c254 = "having",
-      peg$c255 = peg$literalExpectation("HAVING", true),
-      peg$c256 = "limit",
-      peg$c257 = peg$literalExpectation("LIMIT", true),
-      peg$c258 = "asc",
-      peg$c259 = peg$literalExpectation("ASC", true),
-      peg$c260 = function() { return 'ASC';      },
-      peg$c261 = "desc",
-      peg$c262 = peg$literalExpectation("DESC", true),
-      peg$c263 = function() { return 'DESC';     },
-      peg$c264 = "all",
-      peg$c265 = peg$literalExpectation("ALL", true),
-      peg$c266 = function() { return 'ALL';      },
-      peg$c267 = "distinct",
-      peg$c268 = peg$literalExpectation("DISTINCT", true),
-      peg$c269 = function() { return 'DISTINCT'; },
-      peg$c270 = "duplicate",
-      peg$c271 = peg$literalExpectation("DUPLICATE", true),
-      peg$c272 = function() { return 'DUPLICATE';},
-      peg$c273 = "between",
-      peg$c274 = peg$literalExpectation("BETWEEN", true),
-      peg$c275 = function() { return 'BETWEEN';  },
-      peg$c276 = "in",
-      peg$c277 = peg$literalExpectation("IN", true),
-      peg$c278 = function() { return 'IN';       },
-      peg$c279 = "is",
-      peg$c280 = peg$literalExpectation("IS", true),
-      peg$c281 = function() { return 'IS';       },
-      peg$c282 = "like",
-      peg$c283 = peg$literalExpectation("LIKE", true),
-      peg$c284 = function() { return 'LIKE';     },
-      peg$c285 = "contains",
-      peg$c286 = peg$literalExpectation("CONTAINS", true),
-      peg$c287 = function() { return 'CONTAINS'; },
-      peg$c288 = "key",
-      peg$c289 = peg$literalExpectation("KEY", true),
-      peg$c290 = function() { return 'KEY';      },
-      peg$c291 = "not",
-      peg$c292 = peg$literalExpectation("NOT", true),
-      peg$c293 = function() { return 'NOT';      },
-      peg$c294 = "and",
-      peg$c295 = peg$literalExpectation("AND", true),
-      peg$c296 = function() { return 'AND';      },
-      peg$c297 = "or",
-      peg$c298 = peg$literalExpectation("OR", true),
-      peg$c299 = function() { return 'OR';       },
-      peg$c300 = "count",
-      peg$c301 = peg$literalExpectation("COUNT", true),
-      peg$c302 = function() { return 'COUNT';    },
-      peg$c303 = "max",
-      peg$c304 = peg$literalExpectation("MAX", true),
-      peg$c305 = function() { return 'MAX';      },
-      peg$c306 = "min",
-      peg$c307 = peg$literalExpectation("MIN", true),
-      peg$c308 = function() { return 'MIN';      },
-      peg$c309 = "sum",
-      peg$c310 = peg$literalExpectation("SUM", true),
-      peg$c311 = function() { return 'SUM';      },
-      peg$c312 = "avg",
-      peg$c313 = peg$literalExpectation("AVG", true),
-      peg$c314 = function() { return 'AVG';      },
-      peg$c315 = ",",
-      peg$c316 = peg$literalExpectation(",", false),
-      peg$c317 = "[",
-      peg$c318 = peg$literalExpectation("[", false),
-      peg$c319 = "]",
-      peg$c320 = peg$literalExpectation("]", false),
-      peg$c321 = /^[ \t\n\r]/,
-      peg$c322 = peg$classExpectation([" ", "\t", "\n", "\r"], false, false),
-      peg$c323 = "--",
-      peg$c324 = peg$literalExpectation("--", false),
-      peg$c325 = "/*",
-      peg$c326 = peg$literalExpectation("/*", false),
-      peg$c327 = "*/",
-      peg$c328 = peg$literalExpectation("*/", false),
-      peg$c329 = ";",
-      peg$c330 = peg$literalExpectation(";", false),
-      peg$c331 = function() { varList = []; return true; },
-      peg$c332 = function(s) {
+      peg$c177 = function(int_, frac, exp) { return parseFloat(int_ + frac + exp); },
+      peg$c178 = function(int_, frac) { return parseFloat(int_ + frac);       },
+      peg$c179 = function(int_, exp) { return parseFloat(int_ + exp);        },
+      peg$c180 = function(int_) { return parseFloat(int_);              },
+      peg$c181 = function(digit19, digits) { return digit19 + digits;       },
+      peg$c182 = function(op, digit19, digits) { return "-" + digit19 + digits; },
+      peg$c183 = function(op, digit) { return "-" + digit;            },
+      peg$c184 = ".",
+      peg$c185 = peg$literalExpectation(".", false),
+      peg$c186 = function(digits) { return "." + digits; },
+      peg$c187 = function(e, digits) { return e + digits; },
+      peg$c188 = function(digits) { return digits.join(""); },
+      peg$c189 = /^[0-9]/,
+      peg$c190 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c191 = /^[1-9]/,
+      peg$c192 = peg$classExpectation([["1", "9"]], false, false),
+      peg$c193 = /^[0-9a-fA-F]/,
+      peg$c194 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c195 = /^[eE]/,
+      peg$c196 = peg$classExpectation(["e", "E"], false, false),
+      peg$c197 = /^[+\-]/,
+      peg$c198 = peg$classExpectation(["+", "-"], false, false),
+      peg$c199 = function(e, sign) { return e + (sign || ''); },
+      peg$c200 = "null",
+      peg$c201 = peg$literalExpectation("NULL", true),
+      peg$c202 = "true",
+      peg$c203 = peg$literalExpectation("TRUE", true),
+      peg$c204 = "false",
+      peg$c205 = peg$literalExpectation("FALSE", true),
+      peg$c206 = "show",
+      peg$c207 = peg$literalExpectation("SHOW", true),
+      peg$c208 = "drop",
+      peg$c209 = peg$literalExpectation("DROP", true),
+      peg$c210 = "select",
+      peg$c211 = peg$literalExpectation("SELECT", true),
+      peg$c212 = "update",
+      peg$c213 = peg$literalExpectation("UPDATE", true),
+      peg$c214 = "create",
+      peg$c215 = peg$literalExpectation("CREATE", true),
+      peg$c216 = "delete",
+      peg$c217 = peg$literalExpectation("DELETE", true),
+      peg$c218 = "insert",
+      peg$c219 = peg$literalExpectation("INSERT", true),
+      peg$c220 = "replace",
+      peg$c221 = peg$literalExpectation("REPLACE", true),
+      peg$c222 = "explain",
+      peg$c223 = peg$literalExpectation("EXPLAIN", true),
+      peg$c224 = "into",
+      peg$c225 = peg$literalExpectation("INTO", true),
+      peg$c226 = "from",
+      peg$c227 = peg$literalExpectation("FROM", true),
+      peg$c228 = "set",
+      peg$c229 = peg$literalExpectation("SET", true),
+      peg$c230 = "as",
+      peg$c231 = peg$literalExpectation("AS", true),
+      peg$c232 = "table",
+      peg$c233 = peg$literalExpectation("TABLE", true),
+      peg$c234 = "on",
+      peg$c235 = peg$literalExpectation("ON", true),
+      peg$c236 = "left",
+      peg$c237 = peg$literalExpectation("LEFT", true),
+      peg$c238 = "inner",
+      peg$c239 = peg$literalExpectation("INNER", true),
+      peg$c240 = "join",
+      peg$c241 = peg$literalExpectation("JOIN", true),
+      peg$c242 = "union",
+      peg$c243 = peg$literalExpectation("UNION", true),
+      peg$c244 = "values",
+      peg$c245 = peg$literalExpectation("VALUES", true),
+      peg$c246 = "exists",
+      peg$c247 = peg$literalExpectation("EXISTS", true),
+      peg$c248 = "where",
+      peg$c249 = peg$literalExpectation("WHERE", true),
+      peg$c250 = "group",
+      peg$c251 = peg$literalExpectation("GROUP", true),
+      peg$c252 = "by",
+      peg$c253 = peg$literalExpectation("BY", true),
+      peg$c254 = "order",
+      peg$c255 = peg$literalExpectation("ORDER", true),
+      peg$c256 = "having",
+      peg$c257 = peg$literalExpectation("HAVING", true),
+      peg$c258 = "limit",
+      peg$c259 = peg$literalExpectation("LIMIT", true),
+      peg$c260 = "asc",
+      peg$c261 = peg$literalExpectation("ASC", true),
+      peg$c262 = function() { return 'ASC';      },
+      peg$c263 = "desc",
+      peg$c264 = peg$literalExpectation("DESC", true),
+      peg$c265 = function() { return 'DESC';     },
+      peg$c266 = "all",
+      peg$c267 = peg$literalExpectation("ALL", true),
+      peg$c268 = function() { return 'ALL';      },
+      peg$c269 = "distinct",
+      peg$c270 = peg$literalExpectation("DISTINCT", true),
+      peg$c271 = function() { return 'DISTINCT'; },
+      peg$c272 = "duplicate",
+      peg$c273 = peg$literalExpectation("DUPLICATE", true),
+      peg$c274 = function() { return 'DUPLICATE';},
+      peg$c275 = "between",
+      peg$c276 = peg$literalExpectation("BETWEEN", true),
+      peg$c277 = function() { return 'BETWEEN';  },
+      peg$c278 = "in",
+      peg$c279 = peg$literalExpectation("IN", true),
+      peg$c280 = function() { return 'IN';       },
+      peg$c281 = "is",
+      peg$c282 = peg$literalExpectation("IS", true),
+      peg$c283 = function() { return 'IS';       },
+      peg$c284 = "like",
+      peg$c285 = peg$literalExpectation("LIKE", true),
+      peg$c286 = function() { return 'LIKE';     },
+      peg$c287 = "contains",
+      peg$c288 = peg$literalExpectation("CONTAINS", true),
+      peg$c289 = function() { return 'CONTAINS'; },
+      peg$c290 = "key",
+      peg$c291 = peg$literalExpectation("KEY", true),
+      peg$c292 = function() { return 'KEY';      },
+      peg$c293 = "not",
+      peg$c294 = peg$literalExpectation("NOT", true),
+      peg$c295 = function() { return 'NOT';      },
+      peg$c296 = "and",
+      peg$c297 = peg$literalExpectation("AND", true),
+      peg$c298 = function() { return 'AND';      },
+      peg$c299 = "or",
+      peg$c300 = peg$literalExpectation("OR", true),
+      peg$c301 = function() { return 'OR';       },
+      peg$c302 = "count",
+      peg$c303 = peg$literalExpectation("COUNT", true),
+      peg$c304 = function() { return 'COUNT';    },
+      peg$c305 = "max",
+      peg$c306 = peg$literalExpectation("MAX", true),
+      peg$c307 = function() { return 'MAX';      },
+      peg$c308 = "min",
+      peg$c309 = peg$literalExpectation("MIN", true),
+      peg$c310 = function() { return 'MIN';      },
+      peg$c311 = "sum",
+      peg$c312 = peg$literalExpectation("SUM", true),
+      peg$c313 = function() { return 'SUM';      },
+      peg$c314 = "avg",
+      peg$c315 = peg$literalExpectation("AVG", true),
+      peg$c316 = function() { return 'AVG';      },
+      peg$c317 = ",",
+      peg$c318 = peg$literalExpectation(",", false),
+      peg$c319 = "[",
+      peg$c320 = peg$literalExpectation("[", false),
+      peg$c321 = "]",
+      peg$c322 = peg$literalExpectation("]", false),
+      peg$c323 = /^[ \t\n\r]/,
+      peg$c324 = peg$classExpectation([" ", "\t", "\n", "\r"], false, false),
+      peg$c325 = "--",
+      peg$c326 = peg$literalExpectation("--", false),
+      peg$c327 = "/*",
+      peg$c328 = peg$literalExpectation("/*", false),
+      peg$c329 = "*/",
+      peg$c330 = peg$literalExpectation("*/", false),
+      peg$c331 = ";",
+      peg$c332 = peg$literalExpectation(";", false),
+      peg$c333 = function() { varList = []; return true; },
+      peg$c334 = function(s) {
             return {
               stmt : s,
               vars: varList
             }
           },
-      peg$c333 = function(va, e) {
+      peg$c335 = function(va, e) {
           return {
             type : 'assign',
             left : va,
             right: e
           }
         },
-      peg$c334 = function(e) {
+      peg$c336 = function(e) {
         return {
           type : 'return',
           expr: e
         }
       },
-      peg$c335 = function(lt, op, rt, expr) {
+      peg$c337 = function(lt, op, rt, expr) {
             return {
               type    : 'join',
               ltable  : lt, 
@@ -912,7 +932,7 @@ function peg$parse(input, options) {
               on      : expr
             }
           },
-      peg$c336 = function(name, l) {
+      peg$c338 = function(name, l) {
             //compatible with original func_call
             return {
               type : 'function',
@@ -923,13 +943,13 @@ function peg$parse(input, options) {
               }
             }
           },
-      peg$c337 = function(l) {
+      peg$c339 = function(l) {
           return {
             type : 'array',
             value : l
           }
         },
-      peg$c338 = function(name, m) {
+      peg$c340 = function(name, m) {
           //push for analysis
           varList.push(name);
           return {
@@ -938,27 +958,27 @@ function peg$parse(input, options) {
             members : m
           }
         },
-      peg$c339 = function(l) {
+      peg$c341 = function(l) {
           var s = [];
           for (var i = 0; i < l.length; i++) {
             s.push(l[i][1]); 
           }
           return s;
         },
-      peg$c340 = "$",
-      peg$c341 = peg$literalExpectation("$", false),
-      peg$c342 = "return",
-      peg$c343 = peg$literalExpectation("return", true),
-      peg$c344 = ":=",
-      peg$c345 = peg$literalExpectation(":=", false),
-      peg$c346 = function(val, t, w) {
+      peg$c342 = "$",
+      peg$c343 = peg$literalExpectation("$", false),
+      peg$c344 = "return",
+      peg$c345 = peg$literalExpectation("return", true),
+      peg$c346 = ":=",
+      peg$c347 = peg$literalExpectation(":=", false),
+      peg$c348 = function(val, t, w) {
             return {
               type    : 'delete',
               table   : t,
               where   : w
             }
           },
-      peg$c347 = function(db, t) {
+      peg$c349 = function(db, t) {
             return  {
               type: 'table',
               db    : db,
@@ -966,7 +986,7 @@ function peg$parse(input, options) {
               location: location()
             }
           },
-      peg$c348 = function(t) {
+      peg$c350 = function(t) {
             return  {
               type: 'table',
               db    : '',
@@ -1973,10 +1993,10 @@ function peg$parse(input, options) {
   }
 
   function peg$parsetable_base() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13;
 
     s0 = peg$currPos;
-    s1 = peg$parsedb_name();
+    s1 = peg$parsecatalog_name();
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
@@ -1984,25 +2004,49 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parsetable_name();
+            s5 = peg$parsedb_name();
             if (s5 !== peg$FAILED) {
               s6 = peg$parse__();
               if (s6 !== peg$FAILED) {
-                s7 = peg$parseKW_AS();
-                if (s7 === peg$FAILED) {
-                  s7 = null;
-                }
+                s7 = peg$parseDOT();
                 if (s7 !== peg$FAILED) {
                   s8 = peg$parse__();
                   if (s8 !== peg$FAILED) {
-                    s9 = peg$parseident();
-                    if (s9 === peg$FAILED) {
-                      s9 = null;
-                    }
+                    s9 = peg$parsetable_name();
                     if (s9 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c22(s1, s5, s9);
-                      s0 = s1;
+                      s10 = peg$parse__();
+                      if (s10 !== peg$FAILED) {
+                        s11 = peg$parseKW_AS();
+                        if (s11 === peg$FAILED) {
+                          s11 = null;
+                        }
+                        if (s11 !== peg$FAILED) {
+                          s12 = peg$parse__();
+                          if (s12 !== peg$FAILED) {
+                            s13 = peg$parseident();
+                            if (s13 === peg$FAILED) {
+                              s13 = null;
+                            }
+                            if (s13 !== peg$FAILED) {
+                              peg$savedPos = s0;
+                              s1 = peg$c22(s1, s5, s9, s13);
+                              s0 = s1;
+                            } else {
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
+                            }
+                          } else {
+                            peg$currPos = s0;
+                            s0 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
                     } else {
                       peg$currPos = s0;
                       s0 = peg$FAILED;
@@ -2041,25 +2085,49 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parsetable_name();
+      s1 = peg$parsedb_name();
       if (s1 !== peg$FAILED) {
         s2 = peg$parse__();
         if (s2 !== peg$FAILED) {
-          s3 = peg$parseKW_AS();
-          if (s3 === peg$FAILED) {
-            s3 = null;
-          }
+          s3 = peg$parseDOT();
           if (s3 !== peg$FAILED) {
             s4 = peg$parse__();
             if (s4 !== peg$FAILED) {
-              s5 = peg$parseident();
-              if (s5 === peg$FAILED) {
-                s5 = null;
-              }
+              s5 = peg$parsetable_name();
               if (s5 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c23(s1, s5);
-                s0 = s1;
+                s6 = peg$parse__();
+                if (s6 !== peg$FAILED) {
+                  s7 = peg$parseKW_AS();
+                  if (s7 === peg$FAILED) {
+                    s7 = null;
+                  }
+                  if (s7 !== peg$FAILED) {
+                    s8 = peg$parse__();
+                    if (s8 !== peg$FAILED) {
+                      s9 = peg$parseident();
+                      if (s9 === peg$FAILED) {
+                        s9 = null;
+                      }
+                      if (s9 !== peg$FAILED) {
+                        peg$savedPos = s0;
+                        s1 = peg$c23(s1, s5, s9);
+                        s0 = s1;
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -2082,7 +2150,7 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$parseselect_stmt();
+        s1 = peg$parsetable_name();
         if (s1 !== peg$FAILED) {
           s2 = peg$parse__();
           if (s2 !== peg$FAILED) {
@@ -2123,33 +2191,78 @@ function peg$parse(input, options) {
         }
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          s1 = peg$parseLPAREN();
+          s1 = peg$parseselect_stmt();
           if (s1 !== peg$FAILED) {
             s2 = peg$parse__();
             if (s2 !== peg$FAILED) {
-              s3 = peg$parsetable_base();
+              s3 = peg$parseKW_AS();
+              if (s3 === peg$FAILED) {
+                s3 = null;
+              }
               if (s3 !== peg$FAILED) {
                 s4 = peg$parse__();
                 if (s4 !== peg$FAILED) {
-                  s5 = peg$parseRPAREN();
+                  s5 = peg$parseident();
+                  if (s5 === peg$FAILED) {
+                    s5 = null;
+                  }
                   if (s5 !== peg$FAILED) {
-                    s6 = peg$parse__();
-                    if (s6 !== peg$FAILED) {
-                      s7 = peg$parseKW_AS();
-                      if (s7 === peg$FAILED) {
-                        s7 = null;
-                      }
-                      if (s7 !== peg$FAILED) {
-                        s8 = peg$parse__();
-                        if (s8 !== peg$FAILED) {
-                          s9 = peg$parseident();
-                          if (s9 === peg$FAILED) {
-                            s9 = null;
-                          }
-                          if (s9 !== peg$FAILED) {
-                            peg$savedPos = s0;
-                            s1 = peg$c25(s3, s9);
-                            s0 = s1;
+                    peg$savedPos = s0;
+                    s1 = peg$c25(s1, s5);
+                    s0 = s1;
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+          if (s0 === peg$FAILED) {
+            s0 = peg$currPos;
+            s1 = peg$parseLPAREN();
+            if (s1 !== peg$FAILED) {
+              s2 = peg$parse__();
+              if (s2 !== peg$FAILED) {
+                s3 = peg$parsetable_base();
+                if (s3 !== peg$FAILED) {
+                  s4 = peg$parse__();
+                  if (s4 !== peg$FAILED) {
+                    s5 = peg$parseRPAREN();
+                    if (s5 !== peg$FAILED) {
+                      s6 = peg$parse__();
+                      if (s6 !== peg$FAILED) {
+                        s7 = peg$parseKW_AS();
+                        if (s7 === peg$FAILED) {
+                          s7 = null;
+                        }
+                        if (s7 !== peg$FAILED) {
+                          s8 = peg$parse__();
+                          if (s8 !== peg$FAILED) {
+                            s9 = peg$parseident();
+                            if (s9 === peg$FAILED) {
+                              s9 = null;
+                            }
+                            if (s9 !== peg$FAILED) {
+                              peg$savedPos = s0;
+                              s1 = peg$c26(s3, s9);
+                              s0 = s1;
+                            } else {
+                              peg$currPos = s0;
+                              s0 = peg$FAILED;
+                            }
                           } else {
                             peg$currPos = s0;
                             s0 = peg$FAILED;
@@ -2182,48 +2295,48 @@ function peg$parse(input, options) {
               peg$currPos = s0;
               s0 = peg$FAILED;
             }
-          } else {
-            peg$currPos = s0;
-            s0 = peg$FAILED;
-          }
-          if (s0 === peg$FAILED) {
-            s0 = peg$currPos;
-            s1 = peg$currPos;
-            s2 = peg$parseLPAREN();
-            if (s2 !== peg$FAILED) {
-              s3 = peg$parse__();
-              if (s3 !== peg$FAILED) {
-                s4 = peg$currPos;
-                s5 = [];
-                if (peg$c26.test(input.charAt(peg$currPos))) {
-                  s6 = input.charAt(peg$currPos);
-                  peg$currPos++;
-                } else {
-                  s6 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c27); }
-                }
-                while (s6 !== peg$FAILED) {
-                  s5.push(s6);
-                  if (peg$c26.test(input.charAt(peg$currPos))) {
+            if (s0 === peg$FAILED) {
+              s0 = peg$currPos;
+              s1 = peg$currPos;
+              s2 = peg$parseLPAREN();
+              if (s2 !== peg$FAILED) {
+                s3 = peg$parse__();
+                if (s3 !== peg$FAILED) {
+                  s4 = peg$currPos;
+                  s5 = [];
+                  if (peg$c27.test(input.charAt(peg$currPos))) {
                     s6 = input.charAt(peg$currPos);
                     peg$currPos++;
                   } else {
                     s6 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c27); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c28); }
                   }
-                }
-                if (s5 !== peg$FAILED) {
-                  peg$savedPos = s4;
-                  s5 = peg$c28();
-                }
-                s4 = s5;
-                if (s4 !== peg$FAILED) {
-                  s5 = peg$parse__();
+                  while (s6 !== peg$FAILED) {
+                    s5.push(s6);
+                    if (peg$c27.test(input.charAt(peg$currPos))) {
+                      s6 = input.charAt(peg$currPos);
+                      peg$currPos++;
+                    } else {
+                      s6 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c28); }
+                    }
+                  }
                   if (s5 !== peg$FAILED) {
-                    s6 = peg$parseRPAREN();
-                    if (s6 !== peg$FAILED) {
-                      s2 = [s2, s3, s4, s5, s6];
-                      s1 = s2;
+                    peg$savedPos = s4;
+                    s5 = peg$c29();
+                  }
+                  s4 = s5;
+                  if (s4 !== peg$FAILED) {
+                    s5 = peg$parse__();
+                    if (s5 !== peg$FAILED) {
+                      s6 = peg$parseRPAREN();
+                      if (s6 !== peg$FAILED) {
+                        s2 = [s2, s3, s4, s5, s6];
+                        s1 = s2;
+                      } else {
+                        peg$currPos = s1;
+                        s1 = peg$FAILED;
+                      }
                     } else {
                       peg$currPos = s1;
                       s1 = peg$FAILED;
@@ -2240,28 +2353,28 @@ function peg$parse(input, options) {
                 peg$currPos = s1;
                 s1 = peg$FAILED;
               }
-            } else {
-              peg$currPos = s1;
-              s1 = peg$FAILED;
-            }
-            if (s1 !== peg$FAILED) {
-              s2 = peg$parse__();
-              if (s2 !== peg$FAILED) {
-                s3 = peg$parseKW_AS();
-                if (s3 === peg$FAILED) {
-                  s3 = null;
-                }
-                if (s3 !== peg$FAILED) {
-                  s4 = peg$parse__();
-                  if (s4 !== peg$FAILED) {
-                    s5 = peg$parseident();
-                    if (s5 === peg$FAILED) {
-                      s5 = null;
-                    }
-                    if (s5 !== peg$FAILED) {
-                      peg$savedPos = s0;
-                      s1 = peg$c29(s1, s5);
-                      s0 = s1;
+              if (s1 !== peg$FAILED) {
+                s2 = peg$parse__();
+                if (s2 !== peg$FAILED) {
+                  s3 = peg$parseKW_AS();
+                  if (s3 === peg$FAILED) {
+                    s3 = null;
+                  }
+                  if (s3 !== peg$FAILED) {
+                    s4 = peg$parse__();
+                    if (s4 !== peg$FAILED) {
+                      s5 = peg$parseident();
+                      if (s5 === peg$FAILED) {
+                        s5 = null;
+                      }
+                      if (s5 !== peg$FAILED) {
+                        peg$savedPos = s0;
+                        s1 = peg$c30(s1, s5);
+                        s0 = s1;
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$FAILED;
+                      }
                     } else {
                       peg$currPos = s0;
                       s0 = peg$FAILED;
@@ -2278,9 +2391,6 @@ function peg$parse(input, options) {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
               }
-            } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
             }
           }
         }
@@ -2301,7 +2411,7 @@ function peg$parse(input, options) {
         s3 = peg$parseKW_JOIN();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c30();
+          s1 = peg$c31();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2339,7 +2449,7 @@ function peg$parse(input, options) {
         s2 = peg$parseKW_JOIN();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c31();
+          s1 = peg$c32();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2354,6 +2464,20 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parsecatalog_name() {
+    var s0, s1;
+
+    s0 = peg$currPos;
+    s1 = peg$parseident_name();
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c33(s1);
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
   function peg$parsedb_name() {
     var s0, s1;
 
@@ -2361,7 +2485,7 @@ function peg$parse(input, options) {
     s1 = peg$parseident_name();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c32(s1);
+      s1 = peg$c34(s1);
     }
     s0 = s1;
 
@@ -2375,7 +2499,7 @@ function peg$parse(input, options) {
     s1 = peg$parseident();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c33(s1);
+      s1 = peg$c35(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -2383,7 +2507,7 @@ function peg$parse(input, options) {
       s1 = peg$parsevar_decl();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c34(s1);
+        s1 = peg$c36(s1);
       }
       s0 = s1;
     }
@@ -2402,7 +2526,7 @@ function peg$parse(input, options) {
         s3 = peg$parseor_expr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c35(s3);
+          s1 = peg$c37(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2431,7 +2555,7 @@ function peg$parse(input, options) {
         s3 = peg$parseor_expr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c36(s1, s3);
+          s1 = peg$c38(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2478,7 +2602,7 @@ function peg$parse(input, options) {
             s5 = peg$parsecolumn_ref_list();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c37(s5);
+              s1 = peg$c39(s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2593,7 +2717,7 @@ function peg$parse(input, options) {
       s2 = peg$parseor_expr();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c35(s2);
+        s1 = peg$c37(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2622,7 +2746,7 @@ function peg$parse(input, options) {
             s5 = peg$parseorder_by_list();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c37(s5);
+              s1 = peg$c39(s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2745,7 +2869,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c38(s1, s3);
+          s1 = peg$c40(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2812,7 +2936,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c39(s3, s5);
+              s1 = peg$c41(s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2872,7 +2996,7 @@ function peg$parse(input, options) {
                             }
                             if (s13 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c40(s3, s7, s11, s13);
+                              s1 = peg$c42(s3, s7, s11, s13);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -2950,7 +3074,7 @@ function peg$parse(input, options) {
                       }
                       if (s9 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c41(s3, s7, s9);
+                        s1 = peg$c43(s3, s7, s9);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -3021,7 +3145,7 @@ function peg$parse(input, options) {
                             }
                             if (s11 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c42(s3, s5, s9, s11);
+                              s1 = peg$c44(s3, s5, s9, s11);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -3162,11 +3286,11 @@ function peg$parse(input, options) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c43;
+          s3 = peg$c45;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          if (peg$silentFails === 0) { peg$fail(peg$c46); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
@@ -3174,7 +3298,7 @@ function peg$parse(input, options) {
             s5 = peg$parseadditive_expr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c45(s1, s5);
+              s1 = peg$c47(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3211,11 +3335,11 @@ function peg$parse(input, options) {
                 s6 = peg$parse__();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 61) {
-                    s7 = peg$c43;
+                    s7 = peg$c45;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c44); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c46); }
                   }
                   if (s7 !== peg$FAILED) {
                     s8 = peg$parse__();
@@ -3223,7 +3347,7 @@ function peg$parse(input, options) {
                       s9 = peg$parseadditive_expr();
                       if (s9 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c46(s1, s5, s9);
+                        s1 = peg$c48(s1, s5, s9);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -3263,7 +3387,7 @@ function peg$parse(input, options) {
       }
       if (s0 === peg$FAILED) {
         peg$savedPos = peg$currPos;
-        s0 = peg$c47();
+        s0 = peg$c49();
         if (s0) {
           s0 = peg$FAILED;
         } else {
@@ -3306,7 +3430,7 @@ function peg$parse(input, options) {
                             s13 = peg$parsevalue_clause();
                             if (s13 !== peg$FAILED) {
                               peg$savedPos = s0;
-                              s1 = peg$c48(s1, s5, s9, s11, s13);
+                              s1 = peg$c50(s1, s5, s9, s11, s13);
                               s0 = s1;
                             } else {
                               peg$currPos = s0;
@@ -3396,7 +3520,7 @@ function peg$parse(input, options) {
                                   }
                                   if (s15 !== peg$FAILED) {
                                     peg$savedPos = s0;
-                                    s1 = peg$c49(s1, s5, s9, s13, s15);
+                                    s1 = peg$c51(s1, s5, s9, s13, s15);
                                     s0 = s1;
                                   } else {
                                     peg$currPos = s0;
@@ -3479,7 +3603,7 @@ function peg$parse(input, options) {
                         s9 = peg$parsevalue_clause();
                         if (s9 !== peg$FAILED) {
                           peg$savedPos = s0;
-                          s1 = peg$c50(s1, s5, s7, s9);
+                          s1 = peg$c52(s1, s5, s7, s9);
                           s0 = s1;
                         } else {
                           peg$currPos = s0;
@@ -3545,7 +3669,7 @@ function peg$parse(input, options) {
                               }
                               if (s11 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c51(s1, s5, s9, s11);
+                                s1 = peg$c53(s1, s5, s9, s11);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -3614,7 +3738,7 @@ function peg$parse(input, options) {
             s6 = peg$parseRPAREN();
             if (s6 === peg$FAILED) {
               peg$savedPos = peg$currPos;
-              s6 = peg$c52(s4);
+              s6 = peg$c54(s4);
               if (s6) {
                 s6 = peg$FAILED;
               } else {
@@ -3623,7 +3747,7 @@ function peg$parse(input, options) {
             }
             if (s6 !== peg$FAILED) {
               peg$savedPos = s3;
-              s4 = peg$c53(s4);
+              s4 = peg$c55(s4);
               s3 = s4;
             } else {
               peg$currPos = s3;
@@ -3663,7 +3787,7 @@ function peg$parse(input, options) {
     s1 = peg$parseKW_INSERT();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c54();
+      s1 = peg$c56();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -3671,7 +3795,7 @@ function peg$parse(input, options) {
       s1 = peg$parseKW_REPLACE();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c55();
+        s1 = peg$c57();
       }
       s0 = s1;
     }
@@ -3690,7 +3814,7 @@ function peg$parse(input, options) {
         s3 = peg$parsevalues();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c56(s3);
+          s1 = peg$c58(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3731,7 +3855,7 @@ function peg$parse(input, options) {
                     s9 = peg$parseset_list();
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c57(s9);
+                      s1 = peg$c59(s9);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -3856,7 +3980,7 @@ function peg$parse(input, options) {
               s6 = peg$parseRPAREN();
               if (s6 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c58(s3, s4);
+                s1 = peg$c60(s3, s4);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3952,7 +4076,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c59(s1, s2);
+        s1 = peg$c61(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3972,10 +4096,10 @@ function peg$parse(input, options) {
     s0 = peg$parseexpr_list();
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$c60;
+      s1 = peg$c62;
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c61();
+        s1 = peg$c63();
       }
       s0 = s1;
     }
@@ -4049,7 +4173,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c62(s1, s2);
+        s1 = peg$c64(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4129,7 +4253,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c62(s1, s2);
+        s1 = peg$c64(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4151,21 +4275,21 @@ function peg$parse(input, options) {
     if (s1 === peg$FAILED) {
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 33) {
-        s2 = peg$c63;
+        s2 = peg$c65;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c64); }
+        if (peg$silentFails === 0) { peg$fail(peg$c66); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$currPos;
         peg$silentFails++;
         if (input.charCodeAt(peg$currPos) === 61) {
-          s4 = peg$c43;
+          s4 = peg$c45;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          if (peg$silentFails === 0) { peg$fail(peg$c46); }
         }
         peg$silentFails--;
         if (s4 === peg$FAILED) {
@@ -4192,7 +4316,7 @@ function peg$parse(input, options) {
         s3 = peg$parsenot_expr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c65(s3);
+          s1 = peg$c67(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4227,7 +4351,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c66(s1, s3);
+          s1 = peg$c68(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4336,7 +4460,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c67(s1);
+      s1 = peg$c69(s1);
     }
     s0 = s1;
 
@@ -4346,60 +4470,60 @@ function peg$parse(input, options) {
   function peg$parsearithmetic_comparison_operator() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c68) {
-      s0 = peg$c68;
+    if (input.substr(peg$currPos, 2) === peg$c70) {
+      s0 = peg$c70;
       peg$currPos += 2;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c69); }
+      if (peg$silentFails === 0) { peg$fail(peg$c71); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 62) {
-        s0 = peg$c70;
+        s0 = peg$c72;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c71); }
+        if (peg$silentFails === 0) { peg$fail(peg$c73); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c72) {
-          s0 = peg$c72;
+        if (input.substr(peg$currPos, 2) === peg$c74) {
+          s0 = peg$c74;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c73); }
+          if (peg$silentFails === 0) { peg$fail(peg$c75); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c74) {
-            s0 = peg$c74;
+          if (input.substr(peg$currPos, 2) === peg$c76) {
+            s0 = peg$c76;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c75); }
+            if (peg$silentFails === 0) { peg$fail(peg$c77); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 60) {
-              s0 = peg$c76;
+              s0 = peg$c78;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c77); }
+              if (peg$silentFails === 0) { peg$fail(peg$c79); }
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 61) {
-                s0 = peg$c43;
+                s0 = peg$c45;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c44); }
+                if (peg$silentFails === 0) { peg$fail(peg$c46); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c78) {
-                  s0 = peg$c78;
+                if (input.substr(peg$currPos, 2) === peg$c80) {
+                  s0 = peg$c80;
                   peg$currPos += 2;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c79); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c81); }
                 }
               }
             }
@@ -4422,7 +4546,7 @@ function peg$parse(input, options) {
         s3 = peg$parseadditive_expr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c80(s1, s3);
+          s1 = peg$c82(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4459,7 +4583,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseadditive_expr();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c81(s1, s3, s7);
+                  s1 = peg$c83(s1, s3, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4520,7 +4644,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c82(s1);
+      s1 = peg$c84(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -4557,7 +4681,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c82(s1);
+      s1 = peg$c84(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -4594,7 +4718,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c82(s1);
+      s1 = peg$c84(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -4615,7 +4739,7 @@ function peg$parse(input, options) {
         s3 = peg$parsecomparison_expr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c83(s1, s3);
+          s1 = peg$c85(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4652,7 +4776,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseRPAREN();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c84(s1, s5);
+                  s1 = peg$c86(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4691,7 +4815,7 @@ function peg$parse(input, options) {
           s3 = peg$parseselect_stmt();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c85(s1, s3);
+            s1 = peg$c87(s1, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4714,7 +4838,7 @@ function peg$parse(input, options) {
             s3 = peg$parsevar_decl();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c86(s1, s3);
+              s1 = peg$c88(s1, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4753,7 +4877,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseRPAREN();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c87(s1, s5);
+                  s1 = peg$c89(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4792,7 +4916,7 @@ function peg$parse(input, options) {
           s3 = peg$parsevar_decl();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c86(s1, s3);
+            s1 = peg$c88(s1, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4877,7 +5001,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c62(s1, s2);
+        s1 = peg$c64(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4895,19 +5019,19 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 43) {
-      s0 = peg$c88;
+      s0 = peg$c90;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c89); }
+      if (peg$silentFails === 0) { peg$fail(peg$c91); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s0 = peg$c90;
+        s0 = peg$c92;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c91); }
+        if (peg$silentFails === 0) { peg$fail(peg$c93); }
       }
     }
 
@@ -4980,7 +5104,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c92(s1, s2);
+        s1 = peg$c94(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4998,27 +5122,27 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 42) {
-      s0 = peg$c93;
+      s0 = peg$c95;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c94); }
+      if (peg$silentFails === 0) { peg$fail(peg$c96); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 47) {
-        s0 = peg$c95;
+        s0 = peg$c97;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c96); }
+        if (peg$silentFails === 0) { peg$fail(peg$c98); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 37) {
-          s0 = peg$c97;
+          s0 = peg$c99;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c98); }
+          if (peg$silentFails === 0) { peg$fail(peg$c100); }
         }
       }
     }
@@ -5051,7 +5175,7 @@ function peg$parse(input, options) {
                       s5 = peg$parseRPAREN();
                       if (s5 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c99(s3);
+                        s1 = peg$c101(s3);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -5103,7 +5227,7 @@ function peg$parse(input, options) {
             s5 = peg$parsecolumn();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c100(s1, s5);
+              s1 = peg$c102(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5130,7 +5254,7 @@ function peg$parse(input, options) {
       s1 = peg$parsecolumn();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c101(s1);
+        s1 = peg$c103(s1);
       }
       s0 = s1;
     }
@@ -5225,7 +5349,7 @@ function peg$parse(input, options) {
     s1 = peg$parseident_name();
     if (s1 !== peg$FAILED) {
       peg$savedPos = peg$currPos;
-      s2 = peg$c102(s1);
+      s2 = peg$c104(s1);
       if (s2) {
         s2 = peg$FAILED;
       } else {
@@ -5233,7 +5357,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c103(s1);
+        s1 = peg$c105(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5246,30 +5370,30 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 96) {
-        s1 = peg$c104;
+        s1 = peg$c106;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c105); }
+        if (peg$silentFails === 0) { peg$fail(peg$c107); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
-        if (peg$c106.test(input.charAt(peg$currPos))) {
+        if (peg$c108.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c107); }
+          if (peg$silentFails === 0) { peg$fail(peg$c109); }
         }
         if (s3 !== peg$FAILED) {
           while (s3 !== peg$FAILED) {
             s2.push(s3);
-            if (peg$c106.test(input.charAt(peg$currPos))) {
+            if (peg$c108.test(input.charAt(peg$currPos))) {
               s3 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c107); }
+              if (peg$silentFails === 0) { peg$fail(peg$c109); }
             }
           }
         } else {
@@ -5277,15 +5401,15 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 96) {
-            s3 = peg$c104;
+            s3 = peg$c106;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c105); }
+            if (peg$silentFails === 0) { peg$fail(peg$c107); }
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c108(s2);
+            s1 = peg$c110(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5311,7 +5435,7 @@ function peg$parse(input, options) {
     s1 = peg$parsecolumn_name();
     if (s1 !== peg$FAILED) {
       peg$savedPos = peg$currPos;
-      s2 = peg$c102(s1);
+      s2 = peg$c104(s1);
       if (s2) {
         s2 = peg$FAILED;
       } else {
@@ -5319,7 +5443,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c103(s1);
+        s1 = peg$c105(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5335,12 +5459,12 @@ function peg$parse(input, options) {
       if (s1 !== peg$FAILED) {
         s2 = [];
         s3 = peg$currPos;
-        if (peg$c109.test(input.charAt(peg$currPos))) {
+        if (peg$c111.test(input.charAt(peg$currPos))) {
           s4 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c110); }
+          if (peg$silentFails === 0) { peg$fail(peg$c112); }
         }
         if (s4 !== peg$FAILED) {
           s5 = peg$parsebacktik_column();
@@ -5358,12 +5482,12 @@ function peg$parse(input, options) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
           s3 = peg$currPos;
-          if (peg$c109.test(input.charAt(peg$currPos))) {
+          if (peg$c111.test(input.charAt(peg$currPos))) {
             s4 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c110); }
+            if (peg$silentFails === 0) { peg$fail(peg$c112); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parsebacktik_column();
@@ -5381,7 +5505,7 @@ function peg$parse(input, options) {
         }
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c111();
+          s1 = peg$c113();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5401,30 +5525,30 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 96) {
-      s1 = peg$c104;
+      s1 = peg$c106;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c105); }
+      if (peg$silentFails === 0) { peg$fail(peg$c107); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c106.test(input.charAt(peg$currPos))) {
+      if (peg$c108.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c107); }
+        if (peg$silentFails === 0) { peg$fail(peg$c109); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c106.test(input.charAt(peg$currPos))) {
+          if (peg$c108.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c107); }
+            if (peg$silentFails === 0) { peg$fail(peg$c109); }
           }
         }
       } else {
@@ -5432,11 +5556,11 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 96) {
-          s3 = peg$c104;
+          s3 = peg$c106;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c105); }
+          if (peg$silentFails === 0) { peg$fail(peg$c107); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -5472,12 +5596,12 @@ function peg$parse(input, options) {
       if (s2 !== peg$FAILED) {
         s3 = [];
         s4 = peg$currPos;
-        if (peg$c109.test(input.charAt(peg$currPos))) {
+        if (peg$c111.test(input.charAt(peg$currPos))) {
           s5 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c110); }
+          if (peg$silentFails === 0) { peg$fail(peg$c112); }
         }
         if (s5 !== peg$FAILED) {
           s6 = [];
@@ -5504,12 +5628,12 @@ function peg$parse(input, options) {
         while (s4 !== peg$FAILED) {
           s3.push(s4);
           s4 = peg$currPos;
-          if (peg$c109.test(input.charAt(peg$currPos))) {
+          if (peg$c111.test(input.charAt(peg$currPos))) {
             s5 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c110); }
+            if (peg$silentFails === 0) { peg$fail(peg$c112); }
           }
           if (s5 !== peg$FAILED) {
             s6 = [];
@@ -5536,7 +5660,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c112();
+          s1 = peg$c114();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5568,7 +5692,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c113(s1, s2);
+        s1 = peg$c115(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5585,20 +5709,6 @@ function peg$parse(input, options) {
   function peg$parseident_start() {
     var s0;
 
-    if (peg$c114.test(input.charAt(peg$currPos))) {
-      s0 = input.charAt(peg$currPos);
-      peg$currPos++;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c115); }
-    }
-
-    return s0;
-  }
-
-  function peg$parseident_part() {
-    var s0;
-
     if (peg$c116.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
@@ -5610,7 +5720,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsecolumn_char() {
+  function peg$parseident_part() {
     var s0;
 
     if (peg$c118.test(input.charAt(peg$currPos))) {
@@ -5624,17 +5734,31 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parsecolumn_char() {
+    var s0;
+
+    if (peg$c120.test(input.charAt(peg$currPos))) {
+      s0 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c121); }
+    }
+
+    return s0;
+  }
+
   function peg$parseparam() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
     s1 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s2 = peg$c120;
+      s2 = peg$c122;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c121); }
+      if (peg$silentFails === 0) { peg$fail(peg$c123); }
     }
     if (s2 !== peg$FAILED) {
       s3 = peg$parseident_name();
@@ -5651,7 +5775,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c122(s1);
+      s1 = peg$c124(s1);
     }
     s0 = s1;
 
@@ -5688,7 +5812,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseRPAREN();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c123(s1, s5);
+                  s1 = peg$c125(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -5758,7 +5882,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseRPAREN();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c124(s1, s5);
+                  s1 = peg$c126(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -5799,7 +5923,7 @@ function peg$parse(input, options) {
     s1 = peg$parsestar_expr();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c125(s1);
+      s1 = peg$c127(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5814,7 +5938,7 @@ function peg$parse(input, options) {
           s3 = peg$parsecolumn_ref();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c126(s1, s3);
+            s1 = peg$c128(s1, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5838,15 +5962,15 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c93;
+      s1 = peg$c95;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c94); }
+      if (peg$silentFails === 0) { peg$fail(peg$c96); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c127();
+      s1 = peg$c129();
     }
     s0 = s1;
 
@@ -5872,7 +5996,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseRPAREN();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c128(s1, s5);
+                  s1 = peg$c130(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -5989,7 +6113,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c129(s1, s2);
+        s1 = peg$c131(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6010,7 +6134,7 @@ function peg$parse(input, options) {
     s1 = peg$parseKW_NULL();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c130();
+      s1 = peg$c132();
     }
     s0 = s1;
 
@@ -6024,7 +6148,7 @@ function peg$parse(input, options) {
     s1 = peg$parseKW_TRUE();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c131();
+      s1 = peg$c133();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -6032,7 +6156,7 @@ function peg$parse(input, options) {
       s1 = peg$parseKW_FALSE();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c132();
+        s1 = peg$c134();
       }
       s0 = s1;
     }
@@ -6046,11 +6170,11 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c133;
+      s2 = peg$c135;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c134); }
+      if (peg$silentFails === 0) { peg$fail(peg$c136); }
     }
     if (s2 !== peg$FAILED) {
       s3 = [];
@@ -6061,11 +6185,11 @@ function peg$parse(input, options) {
       }
       if (s3 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s4 = peg$c133;
+          s4 = peg$c135;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c134); }
+          if (peg$silentFails === 0) { peg$fail(peg$c136); }
         }
         if (s4 !== peg$FAILED) {
           s2 = [s2, s3, s4];
@@ -6085,11 +6209,11 @@ function peg$parse(input, options) {
     if (s1 === peg$FAILED) {
       s1 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 39) {
-        s2 = peg$c135;
+        s2 = peg$c137;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c136); }
+        if (peg$silentFails === 0) { peg$fail(peg$c138); }
       }
       if (s2 !== peg$FAILED) {
         s3 = [];
@@ -6100,11 +6224,11 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 39) {
-            s4 = peg$c135;
+            s4 = peg$c137;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c136); }
+            if (peg$silentFails === 0) { peg$fail(peg$c138); }
           }
           if (s4 !== peg$FAILED) {
             s2 = [s2, s3, s4];
@@ -6124,7 +6248,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c137(s1);
+      s1 = peg$c139(s1);
     }
     s0 = s1;
 
@@ -6132,23 +6256,6 @@ function peg$parse(input, options) {
   }
 
   function peg$parsesingle_char() {
-    var s0;
-
-    if (peg$c138.test(input.charAt(peg$currPos))) {
-      s0 = input.charAt(peg$currPos);
-      peg$currPos++;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c139); }
-    }
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseescape_char();
-    }
-
-    return s0;
-  }
-
-  function peg$parsedouble_char() {
     var s0;
 
     if (peg$c140.test(input.charAt(peg$currPos))) {
@@ -6165,142 +6272,159 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parsedouble_char() {
+    var s0;
+
+    if (peg$c142.test(input.charAt(peg$currPos))) {
+      s0 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c143); }
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseescape_char();
+    }
+
+    return s0;
+  }
+
   function peg$parseescape_char() {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c142) {
-      s1 = peg$c142;
+    if (input.substr(peg$currPos, 2) === peg$c144) {
+      s1 = peg$c144;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c143); }
+      if (peg$silentFails === 0) { peg$fail(peg$c145); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c144();
+      s1 = peg$c146();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c145) {
-        s1 = peg$c145;
+      if (input.substr(peg$currPos, 2) === peg$c147) {
+        s1 = peg$c147;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c146); }
+        if (peg$silentFails === 0) { peg$fail(peg$c148); }
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c147();
+        s1 = peg$c149();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        if (input.substr(peg$currPos, 2) === peg$c148) {
-          s1 = peg$c148;
+        if (input.substr(peg$currPos, 2) === peg$c150) {
+          s1 = peg$c150;
           peg$currPos += 2;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c149); }
+          if (peg$silentFails === 0) { peg$fail(peg$c151); }
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c150();
+          s1 = peg$c152();
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          if (input.substr(peg$currPos, 2) === peg$c151) {
-            s1 = peg$c151;
+          if (input.substr(peg$currPos, 2) === peg$c153) {
+            s1 = peg$c153;
             peg$currPos += 2;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c152); }
+            if (peg$silentFails === 0) { peg$fail(peg$c154); }
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c153();
+            s1 = peg$c155();
           }
           s0 = s1;
           if (s0 === peg$FAILED) {
             s0 = peg$currPos;
-            if (input.substr(peg$currPos, 2) === peg$c154) {
-              s1 = peg$c154;
+            if (input.substr(peg$currPos, 2) === peg$c156) {
+              s1 = peg$c156;
               peg$currPos += 2;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c155); }
+              if (peg$silentFails === 0) { peg$fail(peg$c157); }
             }
             if (s1 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c156();
+              s1 = peg$c158();
             }
             s0 = s1;
             if (s0 === peg$FAILED) {
               s0 = peg$currPos;
-              if (input.substr(peg$currPos, 2) === peg$c157) {
-                s1 = peg$c157;
+              if (input.substr(peg$currPos, 2) === peg$c159) {
+                s1 = peg$c159;
                 peg$currPos += 2;
               } else {
                 s1 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c158); }
+                if (peg$silentFails === 0) { peg$fail(peg$c160); }
               }
               if (s1 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c159();
+                s1 = peg$c161();
               }
               s0 = s1;
               if (s0 === peg$FAILED) {
                 s0 = peg$currPos;
-                if (input.substr(peg$currPos, 2) === peg$c160) {
-                  s1 = peg$c160;
+                if (input.substr(peg$currPos, 2) === peg$c162) {
+                  s1 = peg$c162;
                   peg$currPos += 2;
                 } else {
                   s1 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c161); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c163); }
                 }
                 if (s1 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c162();
+                  s1 = peg$c164();
                 }
                 s0 = s1;
                 if (s0 === peg$FAILED) {
                   s0 = peg$currPos;
-                  if (input.substr(peg$currPos, 2) === peg$c163) {
-                    s1 = peg$c163;
+                  if (input.substr(peg$currPos, 2) === peg$c165) {
+                    s1 = peg$c165;
                     peg$currPos += 2;
                   } else {
                     s1 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c164); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c166); }
                   }
                   if (s1 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c165();
+                    s1 = peg$c167();
                   }
                   s0 = s1;
                   if (s0 === peg$FAILED) {
                     s0 = peg$currPos;
-                    if (input.substr(peg$currPos, 2) === peg$c166) {
-                      s1 = peg$c166;
+                    if (input.substr(peg$currPos, 2) === peg$c168) {
+                      s1 = peg$c168;
                       peg$currPos += 2;
                     } else {
                       s1 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c167); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c169); }
                     }
                     if (s1 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c168();
+                      s1 = peg$c170();
                     }
                     s0 = s1;
                     if (s0 === peg$FAILED) {
                       s0 = peg$currPos;
-                      if (input.substr(peg$currPos, 2) === peg$c169) {
-                        s1 = peg$c169;
+                      if (input.substr(peg$currPos, 2) === peg$c171) {
+                        s1 = peg$c171;
                         peg$currPos += 2;
                       } else {
                         s1 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c170); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c172); }
                       }
                       if (s1 !== peg$FAILED) {
                         s2 = peg$parsehexDigit();
@@ -6312,7 +6436,7 @@ function peg$parse(input, options) {
                               s5 = peg$parsehexDigit();
                               if (s5 !== peg$FAILED) {
                                 peg$savedPos = s0;
-                                s1 = peg$c171(s2, s3, s4, s5);
+                                s1 = peg$c173(s2, s3, s4, s5);
                                 s0 = s1;
                               } else {
                                 peg$currPos = s0;
@@ -6350,12 +6474,12 @@ function peg$parse(input, options) {
   function peg$parseline_terminator() {
     var s0;
 
-    if (peg$c172.test(input.charAt(peg$currPos))) {
+    if (peg$c174.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c173); }
+      if (peg$silentFails === 0) { peg$fail(peg$c175); }
     }
 
     return s0;
@@ -6368,7 +6492,7 @@ function peg$parse(input, options) {
     s1 = peg$parsenumber();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c174(s1);
+      s1 = peg$c176(s1);
     }
     s0 = s1;
 
@@ -6388,7 +6512,7 @@ function peg$parse(input, options) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c175(s1, s2, s3);
+            s1 = peg$c177(s1, s2, s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6415,7 +6539,7 @@ function peg$parse(input, options) {
           s3 = peg$parse__();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c176(s1, s2);
+            s1 = peg$c178(s1, s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6438,7 +6562,7 @@ function peg$parse(input, options) {
             s3 = peg$parse__();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c177(s1, s2);
+              s1 = peg$c179(s1, s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6459,7 +6583,7 @@ function peg$parse(input, options) {
             s2 = peg$parse__();
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c178(s1);
+              s1 = peg$c180(s1);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6485,7 +6609,7 @@ function peg$parse(input, options) {
       s2 = peg$parsedigits();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c179(s1, s2);
+        s1 = peg$c181(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6500,19 +6624,19 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 45) {
-          s1 = peg$c90;
+          s1 = peg$c92;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c91); }
+          if (peg$silentFails === 0) { peg$fail(peg$c93); }
         }
         if (s1 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 43) {
-            s1 = peg$c88;
+            s1 = peg$c90;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c89); }
+            if (peg$silentFails === 0) { peg$fail(peg$c91); }
           }
         }
         if (s1 !== peg$FAILED) {
@@ -6521,7 +6645,7 @@ function peg$parse(input, options) {
             s3 = peg$parsedigits();
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c180(s1, s2, s3);
+              s1 = peg$c182(s1, s2, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6538,26 +6662,26 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 45) {
-            s1 = peg$c90;
+            s1 = peg$c92;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c91); }
+            if (peg$silentFails === 0) { peg$fail(peg$c93); }
           }
           if (s1 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 43) {
-              s1 = peg$c88;
+              s1 = peg$c90;
               peg$currPos++;
             } else {
               s1 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c89); }
+              if (peg$silentFails === 0) { peg$fail(peg$c91); }
             }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parsedigit();
             if (s2 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c181(s1, s2);
+              s1 = peg$c183(s1, s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6579,17 +6703,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 46) {
-      s1 = peg$c182;
+      s1 = peg$c184;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c183); }
+      if (peg$silentFails === 0) { peg$fail(peg$c185); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsedigits();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c184(s2);
+        s1 = peg$c186(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6612,7 +6736,7 @@ function peg$parse(input, options) {
       s2 = peg$parsedigits();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c185(s1, s2);
+        s1 = peg$c187(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6642,7 +6766,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c186(s1);
+      s1 = peg$c188(s1);
     }
     s0 = s1;
 
@@ -6650,20 +6774,6 @@ function peg$parse(input, options) {
   }
 
   function peg$parsedigit() {
-    var s0;
-
-    if (peg$c187.test(input.charAt(peg$currPos))) {
-      s0 = input.charAt(peg$currPos);
-      peg$currPos++;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c188); }
-    }
-
-    return s0;
-  }
-
-  function peg$parsedigit19() {
     var s0;
 
     if (peg$c189.test(input.charAt(peg$currPos))) {
@@ -6677,7 +6787,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsehexDigit() {
+  function peg$parsedigit19() {
     var s0;
 
     if (peg$c191.test(input.charAt(peg$currPos))) {
@@ -6691,31 +6801,45 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parsehexDigit() {
+    var s0;
+
+    if (peg$c193.test(input.charAt(peg$currPos))) {
+      s0 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c194); }
+    }
+
+    return s0;
+  }
+
   function peg$parsee() {
     var s0, s1, s2;
 
     s0 = peg$currPos;
-    if (peg$c193.test(input.charAt(peg$currPos))) {
+    if (peg$c195.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c194); }
+      if (peg$silentFails === 0) { peg$fail(peg$c196); }
     }
     if (s1 !== peg$FAILED) {
-      if (peg$c195.test(input.charAt(peg$currPos))) {
+      if (peg$c197.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c196); }
+        if (peg$silentFails === 0) { peg$fail(peg$c198); }
       }
       if (s2 === peg$FAILED) {
         s2 = null;
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c197(s1, s2);
+        s1 = peg$c199(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6730,43 +6854,6 @@ function peg$parse(input, options) {
   }
 
   function peg$parseKW_NULL() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c198) {
-      s1 = input.substr(peg$currPos, 4);
-      peg$currPos += 4;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c199); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseident_start();
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        s1 = [s1, s2];
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseKW_TRUE() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -6803,13 +6890,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_FALSE() {
+  function peg$parseKW_TRUE() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c202) {
-      s1 = input.substr(peg$currPos, 5);
-      peg$currPos += 5;
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c202) {
+      s1 = input.substr(peg$currPos, 4);
+      peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c203); }
@@ -6840,13 +6927,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_SHOW() {
+  function peg$parseKW_FALSE() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c204) {
-      s1 = input.substr(peg$currPos, 4);
-      peg$currPos += 4;
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c204) {
+      s1 = input.substr(peg$currPos, 5);
+      peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c205); }
@@ -6877,7 +6964,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_DROP() {
+  function peg$parseKW_SHOW() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -6914,13 +7001,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_SELECT() {
+  function peg$parseKW_DROP() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c208) {
-      s1 = input.substr(peg$currPos, 6);
-      peg$currPos += 6;
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c208) {
+      s1 = input.substr(peg$currPos, 4);
+      peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c209); }
@@ -6951,7 +7038,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_UPDATE() {
+  function peg$parseKW_SELECT() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -6988,7 +7075,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_CREATE() {
+  function peg$parseKW_UPDATE() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -7025,7 +7112,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_DELETE() {
+  function peg$parseKW_CREATE() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -7062,7 +7149,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_INSERT() {
+  function peg$parseKW_DELETE() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -7099,13 +7186,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_REPLACE() {
+  function peg$parseKW_INSERT() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c218) {
-      s1 = input.substr(peg$currPos, 7);
-      peg$currPos += 7;
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c218) {
+      s1 = input.substr(peg$currPos, 6);
+      peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c219); }
@@ -7136,7 +7223,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_EXPLAIN() {
+  function peg$parseKW_REPLACE() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -7173,13 +7260,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_INTO() {
+  function peg$parseKW_EXPLAIN() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c222) {
-      s1 = input.substr(peg$currPos, 4);
-      peg$currPos += 4;
+    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c222) {
+      s1 = input.substr(peg$currPos, 7);
+      peg$currPos += 7;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c223); }
@@ -7210,7 +7297,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_FROM() {
+  function peg$parseKW_INTO() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -7247,16 +7334,53 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseKW_FROM() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c226) {
+      s1 = input.substr(peg$currPos, 4);
+      peg$currPos += 4;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c227); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseident_start();
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        s1 = [s1, s2];
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
   function peg$parseKW_SET() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c226) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c228) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c227); }
+      if (peg$silentFails === 0) { peg$fail(peg$c229); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7288,12 +7412,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c228) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c230) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c229); }
+      if (peg$silentFails === 0) { peg$fail(peg$c231); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7325,12 +7449,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c230) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c232) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c231); }
+      if (peg$silentFails === 0) { peg$fail(peg$c233); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7362,12 +7486,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c232) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c234) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c233); }
+      if (peg$silentFails === 0) { peg$fail(peg$c235); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7399,12 +7523,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c234) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c236) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c235); }
+      if (peg$silentFails === 0) { peg$fail(peg$c237); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7436,12 +7560,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c236) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c238) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c237); }
+      if (peg$silentFails === 0) { peg$fail(peg$c239); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7473,12 +7597,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c238) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c240) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c239); }
+      if (peg$silentFails === 0) { peg$fail(peg$c241); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7510,46 +7634,9 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c240) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c242) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c241); }
-    }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$currPos;
-      peg$silentFails++;
-      s3 = peg$parseident_start();
-      peg$silentFails--;
-      if (s3 === peg$FAILED) {
-        s2 = void 0;
-      } else {
-        peg$currPos = s2;
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        s1 = [s1, s2];
-        s0 = s1;
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseKW_VALUES() {
-    var s0, s1, s2, s3;
-
-    s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c242) {
-      s1 = input.substr(peg$currPos, 6);
-      peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c243); }
@@ -7580,7 +7667,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_EXISTS() {
+  function peg$parseKW_VALUES() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -7617,13 +7704,13 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_WHERE() {
+  function peg$parseKW_EXISTS() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c246) {
-      s1 = input.substr(peg$currPos, 5);
-      peg$currPos += 5;
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c246) {
+      s1 = input.substr(peg$currPos, 6);
+      peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c247); }
@@ -7654,7 +7741,7 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_GROUP() {
+  function peg$parseKW_WHERE() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
@@ -7691,16 +7778,53 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseKW_GROUP() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c250) {
+      s1 = input.substr(peg$currPos, 5);
+      peg$currPos += 5;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c251); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      peg$silentFails++;
+      s3 = peg$parseident_start();
+      peg$silentFails--;
+      if (s3 === peg$FAILED) {
+        s2 = void 0;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        s1 = [s1, s2];
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
   function peg$parseKW_BY() {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c250) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c252) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c251); }
+      if (peg$silentFails === 0) { peg$fail(peg$c253); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7732,12 +7856,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c252) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c254) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c253); }
+      if (peg$silentFails === 0) { peg$fail(peg$c255); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7769,12 +7893,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c254) {
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c256) {
       s1 = input.substr(peg$currPos, 6);
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c255); }
+      if (peg$silentFails === 0) { peg$fail(peg$c257); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7806,12 +7930,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c256) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c258) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c257); }
+      if (peg$silentFails === 0) { peg$fail(peg$c259); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7843,12 +7967,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c258) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c260) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c259); }
+      if (peg$silentFails === 0) { peg$fail(peg$c261); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7863,7 +7987,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c260();
+        s1 = peg$c262();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7881,12 +8005,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c261) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c263) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c262); }
+      if (peg$silentFails === 0) { peg$fail(peg$c264); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7901,7 +8025,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c263();
+        s1 = peg$c265();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7919,12 +8043,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c264) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c266) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c265); }
+      if (peg$silentFails === 0) { peg$fail(peg$c267); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7939,7 +8063,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c266();
+        s1 = peg$c268();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7957,12 +8081,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 8).toLowerCase() === peg$c267) {
+    if (input.substr(peg$currPos, 8).toLowerCase() === peg$c269) {
       s1 = input.substr(peg$currPos, 8);
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c268); }
+      if (peg$silentFails === 0) { peg$fail(peg$c270); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -7977,7 +8101,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c269();
+        s1 = peg$c271();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7995,12 +8119,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 9).toLowerCase() === peg$c270) {
+    if (input.substr(peg$currPos, 9).toLowerCase() === peg$c272) {
       s1 = input.substr(peg$currPos, 9);
       peg$currPos += 9;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c271); }
+      if (peg$silentFails === 0) { peg$fail(peg$c273); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8015,7 +8139,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c272();
+        s1 = peg$c274();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8033,12 +8157,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c273) {
+    if (input.substr(peg$currPos, 7).toLowerCase() === peg$c275) {
       s1 = input.substr(peg$currPos, 7);
       peg$currPos += 7;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c274); }
+      if (peg$silentFails === 0) { peg$fail(peg$c276); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8053,7 +8177,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c275();
+        s1 = peg$c277();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8071,12 +8195,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c276) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c278) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c277); }
+      if (peg$silentFails === 0) { peg$fail(peg$c279); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8091,7 +8215,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c278();
+        s1 = peg$c280();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8109,12 +8233,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c279) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c281) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c280); }
+      if (peg$silentFails === 0) { peg$fail(peg$c282); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8129,7 +8253,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c281();
+        s1 = peg$c283();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8147,12 +8271,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c282) {
+    if (input.substr(peg$currPos, 4).toLowerCase() === peg$c284) {
       s1 = input.substr(peg$currPos, 4);
       peg$currPos += 4;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c283); }
+      if (peg$silentFails === 0) { peg$fail(peg$c285); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8167,7 +8291,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c284();
+        s1 = peg$c286();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8185,12 +8309,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 8).toLowerCase() === peg$c285) {
+    if (input.substr(peg$currPos, 8).toLowerCase() === peg$c287) {
       s1 = input.substr(peg$currPos, 8);
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c286); }
+      if (peg$silentFails === 0) { peg$fail(peg$c288); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8205,7 +8329,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c287();
+        s1 = peg$c289();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8223,12 +8347,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c288) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c290) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c289); }
+      if (peg$silentFails === 0) { peg$fail(peg$c291); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8243,7 +8367,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c290();
+        s1 = peg$c292();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8261,12 +8385,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c291) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c293) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c292); }
+      if (peg$silentFails === 0) { peg$fail(peg$c294); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8281,7 +8405,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c293();
+        s1 = peg$c295();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8299,12 +8423,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c294) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c296) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c295); }
+      if (peg$silentFails === 0) { peg$fail(peg$c297); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8319,7 +8443,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c296();
+        s1 = peg$c298();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8337,12 +8461,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c297) {
+    if (input.substr(peg$currPos, 2).toLowerCase() === peg$c299) {
       s1 = input.substr(peg$currPos, 2);
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c298); }
+      if (peg$silentFails === 0) { peg$fail(peg$c300); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8357,7 +8481,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c299();
+        s1 = peg$c301();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8375,12 +8499,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c300) {
+    if (input.substr(peg$currPos, 5).toLowerCase() === peg$c302) {
       s1 = input.substr(peg$currPos, 5);
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c301); }
+      if (peg$silentFails === 0) { peg$fail(peg$c303); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8395,7 +8519,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c302();
+        s1 = peg$c304();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8413,12 +8537,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c303) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c305) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c304); }
+      if (peg$silentFails === 0) { peg$fail(peg$c306); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8433,7 +8557,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c305();
+        s1 = peg$c307();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8451,12 +8575,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c306) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c308) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c307); }
+      if (peg$silentFails === 0) { peg$fail(peg$c309); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8471,7 +8595,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c308();
+        s1 = peg$c310();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8489,12 +8613,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c309) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c311) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c310); }
+      if (peg$silentFails === 0) { peg$fail(peg$c312); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8509,7 +8633,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c311();
+        s1 = peg$c313();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8527,12 +8651,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c312) {
+    if (input.substr(peg$currPos, 3).toLowerCase() === peg$c314) {
       s1 = input.substr(peg$currPos, 3);
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c313); }
+      if (peg$silentFails === 0) { peg$fail(peg$c315); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -8547,7 +8671,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c314();
+        s1 = peg$c316();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -8565,11 +8689,11 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 46) {
-      s0 = peg$c182;
+      s0 = peg$c184;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c183); }
+      if (peg$silentFails === 0) { peg$fail(peg$c185); }
     }
 
     return s0;
@@ -8579,11 +8703,11 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 44) {
-      s0 = peg$c315;
+      s0 = peg$c317;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c316); }
+      if (peg$silentFails === 0) { peg$fail(peg$c318); }
     }
 
     return s0;
@@ -8593,11 +8717,11 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 42) {
-      s0 = peg$c93;
+      s0 = peg$c95;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c94); }
+      if (peg$silentFails === 0) { peg$fail(peg$c96); }
     }
 
     return s0;
@@ -8635,11 +8759,11 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 91) {
-      s0 = peg$c317;
+      s0 = peg$c319;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c318); }
+      if (peg$silentFails === 0) { peg$fail(peg$c320); }
     }
 
     return s0;
@@ -8649,11 +8773,11 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 93) {
-      s0 = peg$c319;
+      s0 = peg$c321;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c320); }
+      if (peg$silentFails === 0) { peg$fail(peg$c322); }
     }
 
     return s0;
@@ -8695,12 +8819,12 @@ function peg$parse(input, options) {
   function peg$parsewhitespace() {
     var s0;
 
-    if (peg$c321.test(input.charAt(peg$currPos))) {
+    if (peg$c323.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c322); }
+      if (peg$silentFails === 0) { peg$fail(peg$c324); }
     }
 
     return s0;
@@ -8721,12 +8845,12 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c323) {
-      s1 = peg$c323;
+    if (input.substr(peg$currPos, 2) === peg$c325) {
+      s1 = peg$c325;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c324); }
+      if (peg$silentFails === 0) { peg$fail(peg$c326); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -8800,24 +8924,24 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c325) {
-      s1 = peg$c325;
+    if (input.substr(peg$currPos, 2) === peg$c327) {
+      s1 = peg$c327;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c326); }
+      if (peg$silentFails === 0) { peg$fail(peg$c328); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c327) {
-        s5 = peg$c327;
+      if (input.substr(peg$currPos, 2) === peg$c329) {
+        s5 = peg$c329;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c328); }
+        if (peg$silentFails === 0) { peg$fail(peg$c330); }
       }
       peg$silentFails--;
       if (s5 === peg$FAILED) {
@@ -8844,12 +8968,12 @@ function peg$parse(input, options) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c327) {
-          s5 = peg$c327;
+        if (input.substr(peg$currPos, 2) === peg$c329) {
+          s5 = peg$c329;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c328); }
+          if (peg$silentFails === 0) { peg$fail(peg$c330); }
         }
         peg$silentFails--;
         if (s5 === peg$FAILED) {
@@ -8873,12 +8997,12 @@ function peg$parse(input, options) {
         }
       }
       if (s2 !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c327) {
-          s3 = peg$c327;
+        if (input.substr(peg$currPos, 2) === peg$c329) {
+          s3 = peg$c329;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c328); }
+          if (peg$silentFails === 0) { peg$fail(peg$c330); }
         }
         if (s3 !== peg$FAILED) {
           s1 = [s1, s2, s3];
@@ -8905,22 +9029,22 @@ function peg$parse(input, options) {
     s0 = peg$parseEOF();
     if (s0 === peg$FAILED) {
       s0 = [];
-      if (peg$c172.test(input.charAt(peg$currPos))) {
+      if (peg$c174.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c173); }
+        if (peg$silentFails === 0) { peg$fail(peg$c175); }
       }
       if (s1 !== peg$FAILED) {
         while (s1 !== peg$FAILED) {
           s0.push(s1);
-          if (peg$c172.test(input.charAt(peg$currPos))) {
+          if (peg$c174.test(input.charAt(peg$currPos))) {
             s1 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c173); }
+            if (peg$silentFails === 0) { peg$fail(peg$c175); }
           }
         }
       } else {
@@ -8958,11 +9082,11 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 59) {
-      s0 = peg$c329;
+      s0 = peg$c331;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c330); }
+      if (peg$silentFails === 0) { peg$fail(peg$c332); }
     }
 
     return s0;
@@ -8986,7 +9110,7 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     peg$savedPos = peg$currPos;
-    s1 = peg$c331();
+    s1 = peg$c333();
     if (s1) {
       s1 = void 0;
     } else {
@@ -9001,7 +9125,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c332(s3);
+          s1 = peg$c334(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9034,7 +9158,7 @@ function peg$parse(input, options) {
             s5 = peg$parseproc_expr();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c333(s1, s5);
+              s1 = peg$c335(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9071,7 +9195,7 @@ function peg$parse(input, options) {
         s3 = peg$parseproc_expr();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c334(s3);
+          s1 = peg$c336(s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9172,7 +9296,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c62(s1, s2);
+        s1 = peg$c64(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9252,7 +9376,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c62(s1, s2);
+        s1 = peg$c64(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -9285,7 +9409,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseon_clause();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c335(s1, s3, s5, s7);
+                  s1 = peg$c337(s1, s3, s5, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9342,7 +9466,7 @@ function peg$parse(input, options) {
                     s5 = peg$parseRPAREN();
                     if (s5 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c99(s3);
+                      s1 = peg$c101(s3);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -9391,7 +9515,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseRPAREN();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c336(s1, s5);
+                  s1 = peg$c338(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9520,7 +9644,7 @@ function peg$parse(input, options) {
             s5 = peg$parseRBRAKE();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c337(s3);
+              s1 = peg$c339(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9557,7 +9681,7 @@ function peg$parse(input, options) {
         s3 = peg$parsemem_chain();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c338(s2, s3);
+          s1 = peg$c340(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -9582,11 +9706,11 @@ function peg$parse(input, options) {
     s1 = [];
     s2 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 46) {
-      s3 = peg$c182;
+      s3 = peg$c184;
       peg$currPos++;
     } else {
       s3 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c183); }
+      if (peg$silentFails === 0) { peg$fail(peg$c185); }
     }
     if (s3 !== peg$FAILED) {
       s4 = peg$parseident_name();
@@ -9605,11 +9729,11 @@ function peg$parse(input, options) {
       s1.push(s2);
       s2 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s3 = peg$c182;
+        s3 = peg$c184;
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c183); }
+        if (peg$silentFails === 0) { peg$fail(peg$c185); }
       }
       if (s3 !== peg$FAILED) {
         s4 = peg$parseident_name();
@@ -9627,7 +9751,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c339(s1);
+      s1 = peg$c341(s1);
     }
     s0 = s1;
 
@@ -9638,22 +9762,8 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 36) {
-      s0 = peg$c340;
+      s0 = peg$c342;
       peg$currPos++;
-    } else {
-      s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c341); }
-    }
-
-    return s0;
-  }
-
-  function peg$parseKW_RETURN() {
-    var s0;
-
-    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c342) {
-      s0 = input.substr(peg$currPos, 6);
-      peg$currPos += 6;
     } else {
       s0 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c343); }
@@ -9662,15 +9772,29 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseKW_ASSIGN() {
+  function peg$parseKW_RETURN() {
     var s0;
 
-    if (input.substr(peg$currPos, 2) === peg$c344) {
-      s0 = peg$c344;
-      peg$currPos += 2;
+    if (input.substr(peg$currPos, 6).toLowerCase() === peg$c344) {
+      s0 = input.substr(peg$currPos, 6);
+      peg$currPos += 6;
     } else {
       s0 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$c345); }
+    }
+
+    return s0;
+  }
+
+  function peg$parseKW_ASSIGN() {
+    var s0;
+
+    if (input.substr(peg$currPos, 2) === peg$c346) {
+      s0 = peg$c346;
+      peg$currPos += 2;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c347); }
     }
 
     return s0;
@@ -9698,7 +9822,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c346(s1, s5, s7);
+                  s1 = peg$c348(s1, s5, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -9761,7 +9885,7 @@ function peg$parse(input, options) {
             s5 = peg$parsetable_name();
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c347(s1, s5);
+              s1 = peg$c349(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -9788,7 +9912,7 @@ function peg$parse(input, options) {
       s1 = peg$parsetable_name();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c348(s1);
+        s1 = peg$c350(s1);
       }
       s0 = s1;
     }

--- a/packages/sql-parser/index.d.ts
+++ b/packages/sql-parser/index.d.ts
@@ -143,6 +143,7 @@ export type FromTableNode = TableNode | SubqueryNode | IncompleteSubqueryNode
 
 export type TableNode = {
   type: 'table',
+  catalog: string,
   db: string,
   table: string,
   as: string | null,

--- a/packages/sql-parser/index.d.ts
+++ b/packages/sql-parser/index.d.ts
@@ -88,7 +88,7 @@ export type FromClause = {
 export type WhereClause = {
   type: 'where',
   keyword: KeywordNode,
-  expression: BinaryExpressionNode,
+  expression: BinaryExpressionNode | ColumnRefNode,
   location: NodeRange
 }
 

--- a/packages/sql-parser/index.d.ts
+++ b/packages/sql-parser/index.d.ts
@@ -143,8 +143,8 @@ export type FromTableNode = TableNode | SubqueryNode | IncompleteSubqueryNode
 
 export type TableNode = {
   type: 'table',
-  catalog: string,
-  db: string,
+  catalog: string | null,
+  db: string | null,
   table: string,
   as: string | null,
   location: NodeRange,

--- a/packages/sql-parser/index.js
+++ b/packages/sql-parser/index.js
@@ -1,6 +1,7 @@
 const Parser = require('./base/parser');
 const FromClauseParser = require('./base/fromClauseParser')
 Parser.reservedMap = require('./base/reservedmap');
+FromClauseParser.reservedMap = require('./base/reservedmap');
 
 exports.parse = function (sql){
   var ap = Parser.parse(sql);

--- a/packages/sql-parser/parser.pegjs
+++ b/packages/sql-parser/parser.pegjs
@@ -249,13 +249,29 @@ table_join
 
 //NOTE that ,the table assigned to `var` shouldn't write in `table_join`
 table_base
-  = db:db_name __ DOT __ t:table_name __ KW_AS? __ alias:ident? {
+  = cat:catalog_name __ DOT __ db:db_name __ DOT __ t:table_name __ KW_AS? __ alias:ident? {
       if (t && t.type == 'var') {
         t.as = alias;
         return t;
       } else {
         return  {
           type: 'table',
+          catalog: cat,
+          db    : db,
+          table : t,
+          as    : alias,
+          location: location()
+        }
+      }
+    }
+  / db:db_name __ DOT __ t:table_name __ KW_AS? __ alias:ident? {
+      if (t && t.type == 'var') {
+        t.as = alias;
+        return t;
+      } else {
+        return  {
+          type: 'table',
+          catalog: '',
           db    : db,
           table : t,
           as    : alias,
@@ -270,6 +286,7 @@ table_base
       } else {
         return  {
           type: 'table',
+          catalog: '',
           db    : '',
           table : t,
           as    : alias,
@@ -290,6 +307,11 @@ table_base
 join_op
   = KW_LEFT __ KW_JOIN { return 'LEFT JOIN'; }
   / (KW_INNER __)? KW_JOIN { return 'INNER JOIN'; }
+
+catalog_name
+  = cat: ident_name {
+    return cat;
+  }
 
 db_name
   = db:ident_name {

--- a/packages/sql-parser/test/nested.test.js
+++ b/packages/sql-parser/test/nested.test.js
@@ -1,6 +1,31 @@
 const { parse } = require('../index')
 
 describe('nested columns', () => {
+  it('database.table should parse', () => {
+    const sql = `
+      SELECT
+      tab1.col1
+      FROM database.table1 as tab1
+    `
+     const result = parse(sql)
+     expect(result).toBeDefined()
+     expect(result).toMatchObject({ type: 'select' })
+     expect(result.columns[0].expr).toMatchObject({ column: 'col1', table: 'tab1', type: 'column_ref' })
+     expect(result.from.tables[0]).toMatchObject({ db: 'database', table: 'table1', catalog: '' })
+  })
+  it('catalog.database.table should parse', () => {
+    const sql = `
+      SELECT
+      tab1.col1
+      FROM catalog1.database2.table3 as tab1
+    `
+     const result = parse(sql)
+     expect(result).toBeDefined()
+     expect(result).toMatchObject({ type: 'select' })
+     expect(result.columns[0].expr).toMatchObject({ column: 'col1', table: 'tab1', type: 'column_ref' })
+     expect(result.from.tables[0]).toMatchObject({ db: 'database2', table: 'table3', catalog: 'catalog1' })
+  })
+
   it('column name y.z should success to parse', () => {
     const sql = '\
       SELECT\

--- a/packages/sql-parser/test/subquery.test.js
+++ b/packages/sql-parser/test/subquery.test.js
@@ -1,16 +1,35 @@
-const { parse } = require('../index')
+const { parse, parseFromClause } = require('../index')
 
 describe('Subquery in where clause', () => {
- it('should success to parse', () => {
+  it('should success to parse', () => {
     const sql = `
       SELECT *
       FROM T1
       WHERE T1.num = (SELECT max(T2.num) from T2)
     `
-     const result = parse(sql)
-     expect(result).toBeDefined()
-     expect(result).toMatchObject({ type: 'select' })
-     expect(result.where.expression.left).toMatchObject({ type: 'column_ref' })
-     expect(result.where.expression.right).toMatchObject({ type: 'select' })
+    const result = parse(sql)
+    expect(result).toBeDefined()
+    expect(result).toMatchObject({ type: 'select' })
+    expect(result.where.expression.left).toMatchObject({ type: 'column_ref' })
+    expect(result.where.expression.right).toMatchObject({ type: 'select' })
   })
+  it('should not accept WHERE as an alias', () => {
+    const sql = `
+      SELECT *
+      FROM T1
+      WHERE T1.num = (SELECT max(T2.num) from T2)
+    `
+    const result = parse(sql)
+    expect(result).toBeDefined()
+    expect(result).toMatchObject({ type: 'select' })
+    expect(result.from.tables[0]).toMatchObject({ as: null, table: 'T1' })
+  })
+  it('should not accept WHERE as an alias parseFromClause', () => {
+    const sql = `SELECT * FROM T1 WHERE T1.`
+    const result = parseFromClause(sql)
+    expect(result).toBeDefined()
+    expect(result.from.tables[0]).toMatchObject({ as: null, table: 'T1' })
+  })
+
+
 })


### PR DESCRIPTION
This PR should be applied after the documentation PR I've created earlier.

This pull request contains the main support for code completion of nested columns, it adds support for the following:

- Nested columns names using multi-part dot separated paths
- Support for spaces in nested columns names (backtiks each segment)
- Visually distinct icons for `table`, `column`, `alias`, `functions` suggestions
- Added support for code-completion of
	- Functions including descriptions
	- Table alias
	- Table alias followed by dot
	- Partially typed columns including multi-part fields (needed insertText)
        - Map and Array subscripts `map_col['key'].<tab>`, `array_col[0].<tab>`

More details can be found in example/jupyterlab/README.md

This is a fairly large PR which I've tested as much as I could. Please feel free to reach out if you have any questions and want to discuss changes.

Cheers
