### PR TITLE
fix bug completing functions

### DIFF
--- a/packages/server/src/complete.ts
+++ b/packages/server/src/complete.ts
@@ -592,6 +592,16 @@ class Completer {
       if (logger.isDebugEnabled()) logger.debug(JSON.stringify(columnRef))
       return columnRef
     }
+    else if (columns.type == 'star') {
+      if (ast.type === 'select' && ast.where?.expression) {
+        // columns in where clause  
+        const columnRefs = [ast.where.expression]
+        // column at position
+        const columnRef = this.getColumnRefByPos(columnRefs)
+        if (logger.isDebugEnabled()) logger.debug(JSON.stringify(columnRef))
+        return columnRef
+      }
+    }
     return undefined
   }
 

--- a/packages/server/test/complete.test.ts
+++ b/packages/server/test/complete.test.ts
@@ -169,6 +169,26 @@ describe('on blank space', () => {
     ]
     expect(result.candidates).toEqual(expect.arrayContaining(expected))
   })
+
+  test("complete function inside WHERE select star", () => {
+    const result = complete('SELECT * FROM tab1 WHERE arr', { line: 0, column: 28 }, SIMPLE_SCHEMA)
+    expect(result.candidates.length).toEqual(2) // TODO whare are they?
+    let expected = [
+      expect.objectContaining({ label: 'array_concat()' }),
+      expect.objectContaining({ label: 'array_contains()' }),
+    ]
+    expect(result.candidates).toEqual(expect.arrayContaining(expected))
+  })
+
+  test("complete function inside WHERE", () => {
+    const result = complete('SELECT col1 FROM tab1 WHERE arr', { line: 0, column: 31 }, SIMPLE_SCHEMA)
+    expect(result.candidates.length).toEqual(2) // TODO whare are they?
+    let expected = [
+      expect.objectContaining({ label: 'array_concat()' }),
+      expect.objectContaining({ label: 'array_contains()' }),
+    ]
+    expect(result.candidates).toEqual(expect.arrayContaining(expected))
+  })
 })
 
 describe('TableName completion', () => {


### PR DESCRIPTION
function did not complete with a

SELECT * FROM TAB1 WHERE func1

it did work for cases where the columns are declared in the select

SELECT a,b FROM TAB1 WHERE func1

it now works with select star also