### PR TITLE
Fix server being booted twice

### DIFF
--- a/packages/server/bin/cli.ts
+++ b/packages/server/bin/cli.ts
@@ -2,7 +2,7 @@ import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 import { ConnectionMethod, createServer } from '../src/createServer'
 
-const cli = yargs(hideBin(process.argv))
+yargs(hideBin(process.argv))
   .usage('SQL Language Server Command Line Interface')
   .command('up', 'run sql-language-server', (v) => {
     return v.option('method', {
@@ -22,13 +22,9 @@ const cli = yargs(hideBin(process.argv))
     process.stdin.resume()
   })
   .example('$0 up --method stdio', ': start up sql-language-server - communicate via stdio')
+  .demandCommand()
   .help()
-
-cli.parse()
-
-if ((cli.argv as any)._.length === 0) {
-  cli.showHelp()
-}
+  .parse();
 
 process.stdin.on('close', () => {
   process.exit(0);


### PR DESCRIPTION
This PR fixes issue #128. The current code actually causes the language server to be booted twice! neovim's LSP support doesn't like this because it means it's receiving two responses for every message it sends.

This was a tricky bug to figure out: It turns out that calling `cli.argv` is equivalent to calling `parse()`. This means that the command-parsing logic is actually run twice, causing the server to be booted twice in some circumstances. I changed the code to use `demandCommand()` -- this will output the help message if a command is outputted, and it saves having to make the manual check on `cli.argv` to output the help command.