### PR TITLE
Do not throw an error when it's failed to parse

### DIFF
--- a/packages/sqlint/src/rules/index.ts
+++ b/packages/sqlint/src/rules/index.ts
@@ -1,4 +1,5 @@
 import { parse, NodeRange, AST, Node, BaseNode } from '@joe-re/sql-parser'
+import log4js from 'log4js'
 import { Fixer, FixDescription, createFixer } from '../fixer'
 import { reservedWordCase } from './reservedWordCase'
 import { spaceSurroundingOperators } from './spaceSurroundingOperators'
@@ -8,6 +9,8 @@ import { alignColumnToTheFirst } from './alignColumnToTheFirst'
 import { whereClauseNewLine } from './whereClauseNewLine'
 import { alignWhereClauseToTheFirst } from './alignWhereClauseToTheFirst'
 import { requireAsToRenameColumn } from './requireAsToRenameColumn'
+
+const logger = log4js.getLogger()
 
 export type Diagnostic = {
   message: string
@@ -75,8 +78,14 @@ export function execute(sql: string, config: Config): Diagnostic[] {
   registerRule(whereClauseNewLine, config, sql)
   registerRule(alignWhereClauseToTheFirst, config, sql)
   registerRule(requireAsToRenameColumn, config, sql)
-  const ast = parse(sql)
-  return walk(ast)
+
+  try {
+    const ast = parse(sql)
+    return walk(ast)
+  } catch (e) {
+    logger.debug(e)
+    return []
+  }
 }
 
 function registerRule<N extends Node, RC>(


### PR DESCRIPTION
It can be failed even if the sql text on the editor is correct because lint check can be apllied to a partial part depending on the cursor position. Instead of throwing an error, returns empty result.